### PR TITLE
Updated DATABASE_URL example link

### DIFF
--- a/with-nextjs-get-server-side-props/README.md
+++ b/with-nextjs-get-server-side-props/README.md
@@ -19,7 +19,7 @@ cp .env.example .env
 Store your Neon credentials in your `.env` file.
 
 ```
-DATABASE_URL="postgresql://<user>:<password>@<endpoint_hostname>.neon.tech:<port>/<dbname>?sslmode=require"
+DATABASE_URL="postgresql://<user>:<password>@<endpoint_hostname>.neon.tech/<dbname>?sslmode=require"
 ```
 
 - `user` is the database user.

--- a/with-nextjs-get-server-side-props/README.md
+++ b/with-nextjs-get-server-side-props/README.md
@@ -19,7 +19,7 @@ cp .env.example .env
 Store your Neon credentials in your `.env` file.
 
 ```
-DATABASE_URL="postgresql://neondb_owner:...@ep-...us-east-1.aws.neon.tech/neondb?sslmode=require"
+DATABASE_URL="postgresql://<user>:<password>@<endpoint_hostname>.neon.tech:<port>/<dbname>?sslmode=require"
 ```
 
 - `user` is the database user.


### PR DESCRIPTION
The `DATABASE_URL` value didn’t match what was in the documentation, and it also didn’t include the values like `user`, `password`, etc, mentioned in the docs or README. This could make it confusing for people to set up the example repo if they forked it before reading the documentation.