### PR TITLE
feat: add bootstrap.yaml template manifest

### DIFF
--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -1,0 +1,9 @@
+templates:
+  - id: hono
+    title: "Hono API (Drizzle, Neon Postgres) on Neon Functions"
+    description: "A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function."
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono


### PR DESCRIPTION
## Summary
- Adds a `bootstrap.yaml` file at the repo root containing metadata for available bootstrap templates (id, title, description, source location)
- Enables `neonctl bootstrap` and `neon-init` to fetch the template list at runtime from this repo instead of hardcoding it in the CLI source
- Adding new templates becomes a single file edit in this repo — no CLI release needed

## Test plan
- [ ] Verify `bootstrap.yaml` is valid YAML and matches the schema expected by neonctl
- [ ] Update `neonctl bootstrap` to fetch from this manifest instead of the hardcoded `TEMPLATES` array

This pull request and its description were written by Isaac.