### PR TITLE
feat: add requires metadata to bootstrap manifest

### DIFF
--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -2,6 +2,9 @@ templates:
   - id: hono
     title: "Hono API (Drizzle, Neon Postgres) on Neon Functions"
     description: "A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function."
+    requires:
+      - database
+      - functions
     source:
       owner: neondatabase
       repo: examples


### PR DESCRIPTION
## Summary
- Adds a `requires` field to the Hono template in `bootstrap.yaml`
- The Hono template declares `requires: [database, functions]` since it needs a Neon database and runs on Neon Functions
- `neon-init` uses this metadata to automatically skip setup phases the template doesn't need (e.g. skipping Neon Auth for templates that don't require it)
- Templates without `requires` default to `["database"]` for backward compatibility

## Test plan
- [ ] Verify `bootstrap.yaml` is valid YAML
- [ ] Verify `neonctl bootstrap` and `neon-init` parse the `requires` field correctly (both handle missing field gracefully)

This pull request and its description were written by Isaac.