### PR TITLE
Add with-mcp example (MCP server with CRUD contact tools on Neon Functions)

### DIFF
--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -35,6 +35,17 @@ templates:
       repo: examples
       ref: main
       subdir: with-mastra
+  - id: mcp
+    title: "MCP server (Model Context Protocol SDK, Hono, Drizzle) on Neon Functions"
+    description: "An MCP server on Neon Functions exposing CRUD tools (create, update, delete, search) over a contact-management database. Built with the Anthropic MCP TypeScript SDK and Hono's streamable HTTP transport, backed by Neon Postgres via Drizzle."
+    services:
+      - Postgres
+      - Functions
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-mcp
   - id: realtime-chat
     title: "Realtime chat (Next.js, Neon Auth, WebSockets) on Neon Functions"
     description: "A full-stack realtime chat: a Next.js app with Neon Auth talking over WebSockets to a Hono server on Neon Functions. Messages are stored in Neon Postgres via Drizzle and fanned out to all clients across isolates with Postgres LISTEN/NOTIFY."

--- a/with-ai-sdk/README.md
+++ b/with-ai-sdk/README.md
@@ -69,8 +69,6 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-> On a brand-new project, `neon link` runs an implicit `env pull` that will warn it can't find the services declared in `neon.ts` (e.g. `bucket:images` and the AI Gateway). That's expected — provision them in the next step, then the variables can be pulled.
-
 ## Provision the declared services
 
 `neon.ts` declares an object-storage bucket and the AI Gateway, but `neon link` does **not** create them — so the credentials and endpoints don't exist yet for `env pull` to read. Apply the policy first to provision them on your branch:

--- a/with-ai-sdk/README.md
+++ b/with-ai-sdk/README.md
@@ -71,13 +71,13 @@ If you let your agent drive this, add `--agent` to skip interactive mode.
 
 ## Provision and deploy
 
-`neon.ts` declares an object-storage bucket and the AI Gateway, but `neon link` does **not** create them — the credentials and endpoints don't exist until the policy is applied. `neon deploy` applies the policy (creating the bucket, enabling the AI Gateway, and deploying the agent as a Neon Function) and then pulls the resulting branch-scoped variables into `.env.local`:
+Provision the services declared in `neon.ts`:
 
 ```bash
 neon deploy
 ```
 
-> `neon deploy` automatically runs an env pull after applying the policy, writing the provisioned variables into `.env.local` (or `.env` if that's what the project uses). Because `neon.ts` enables the AI Gateway and a bucket, that includes a freshly minted `OPENAI_API_KEY` / `OPENAI_BASE_URL` and the `AWS_*` storage variables alongside `DATABASE_URL` — see `.env.example` for the full set. No separate `env pull` step is needed.
+> Note: `neon deploy` automatically runs an `env pull` that fetches the declared services' credentials and environment variables and writes them to a local `.env.local` file for development.
 
 ## Apply the schema
 

--- a/with-ai-sdk/README.md
+++ b/with-ai-sdk/README.md
@@ -69,25 +69,15 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-## Provision the declared services
+## Provision and deploy
 
-`neon.ts` declares an object-storage bucket and the AI Gateway, but `neon link` does **not** create them — so the credentials and endpoints don't exist yet for `env pull` to read. Apply the policy first to provision them on your branch:
-
-```bash
-neon config apply
-```
-
-This creates the bucket and enables the AI Gateway (and registers the function), so their credentials are ready to pull.
-
-## Configure your environment
-
-Now that the services exist, pull your branch-scoped variables into `.env.local`:
+`neon.ts` declares an object-storage bucket and the AI Gateway, but `neon link` does **not** create them — the credentials and endpoints don't exist until the policy is applied. `neon deploy` applies the policy (creating the bucket, enabling the AI Gateway, and deploying the agent as a Neon Function) and then pulls the resulting branch-scoped variables into `.env.local`:
 
 ```bash
-neon env pull
+neon deploy
 ```
 
-Because `neon.ts` enables the AI Gateway and a bucket, the pull mints a branch credential and writes `OPENAI_API_KEY` / `OPENAI_BASE_URL` and the `AWS_*` storage variables alongside `DATABASE_URL`. See `.env.example` for the full set.
+> `neon deploy` automatically runs an env pull after applying the policy, writing the provisioned variables into `.env.local` (or `.env` if that's what the project uses). Because `neon.ts` enables the AI Gateway and a bucket, that includes a freshly minted `OPENAI_API_KEY` / `OPENAI_BASE_URL` and the `AWS_*` storage variables alongside `DATABASE_URL` — see `.env.example` for the full set. No separate `env pull` step is needed.
 
 ## Apply the schema
 
@@ -123,10 +113,18 @@ curl -N -X POST http://localhost:8787 \
   ]}'
 ```
 
-## Deploy to Neon Functions
+## Test your deployed function
+
+You already deployed the agent in the provisioning step. Grab its invocation URL and call it:
 
 ```bash
-neon deploy
+# List the function to find its invocation URL
+neon functions get imagegen
+
+# Then call it (replace with your URL)
+curl -N -X POST https://<your-branch>-imagegen.compute.<region>.aws.neon.tech \
+  -H 'content-type: application/json' \
+  -d '{"messages":[{"role":"user","content":"Please draw a robot reading a book."}]}'
 ```
 
-This applies the `neon.ts` policy (creating the bucket + enabling the AI Gateway on the branch if needed) and deploys the agent as a Neon Function.
+Redeploy after changing the function with `neon deploy`.

--- a/with-hono/README.md
+++ b/with-hono/README.md
@@ -53,31 +53,7 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-## Provision the declared services
-
-`neon.ts` declares the `todos` function, but `neon link` does **not** provision the services it declares — `env pull` fails fast until they exist on the branch. Apply the policy first:
-
-```bash
-neonctl config apply
-```
-
-This registers the declared function on your branch so the environment pull can resolve everything in `neon.ts`.
-
-## Configure your environment
-
-With the policy applied, pull your branch-scoped environment variables into `.env.local`:
-
-```bash
-neonctl env pull
-```
-
-Inspect your `.env.local` file and ensure the `DATABASE_URL` has been set:
-
-```
-DATABASE_URL="postgresql://neondb_owner:...@ep-...us-east-1.aws.neon.tech/neondb?sslmode=require"
-```
-
-You can also find your connection string in the [Neon Console](https://console.neon.tech).
+`neon link` pulls your branch-scoped environment variables — including `DATABASE_URL` — into `.env.local`. You can also find your connection string in the [Neon Console](https://console.neon.tech).
 
 ## Apply the schema
 

--- a/with-hono/README.md
+++ b/with-hono/README.md
@@ -53,8 +53,6 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-> On a brand-new project, `neon link` runs an implicit `env pull` that will warn it can't find the function declared in `neon.ts`. That's expected — provision it in the next step, then the variables can be pulled.
-
 ## Provision the declared services
 
 `neon.ts` declares the `todos` function, but `neon link` does **not** provision the services it declares — `env pull` fails fast until they exist on the branch. Apply the policy first:

--- a/with-mastra/README.md
+++ b/with-mastra/README.md
@@ -53,27 +53,17 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-> The Neon AI Gateway is a Preview feature. Link to a project/region where AI Gateway early access is enabled, otherwise `neon dev` / `neon env pull` can't mint the gateway credentials.
+> The Neon AI Gateway is a Preview feature. Link to a project/region where AI Gateway early access is enabled, otherwise `neon dev` / `neon deploy` can't mint the gateway credentials.
 
-## Provision the declared services
+## Provision and deploy
 
-`neon.ts` enables the AI Gateway, but `neon link` does **not** provision it — so the gateway credentials don't exist yet for `env pull` to read. Apply the policy first to enable it on your branch:
-
-```bash
-neon config apply
-```
-
-This enables the AI Gateway (and registers the function), so its credentials are ready to pull.
-
-## Configure your environment
-
-Now that the AI Gateway exists, pull your branch-scoped variables into `.env.local`:
+`neon.ts` enables the AI Gateway, but `neon link` does **not** provision it — the gateway credentials don't exist until the policy is applied. `neon deploy` applies the policy (enabling the AI Gateway and deploying the agent as a Neon Function) and then pulls the resulting branch-scoped variables into `.env.local`:
 
 ```bash
-neon env pull
+neon deploy
 ```
 
-Because `neon.ts` enables the AI Gateway, the pull mints a branch credential and writes the gateway variables (`OPENAI_API_KEY`, `OPENAI_BASE_URL`) alongside `DATABASE_URL` — see `.env.example` for the full set.
+> `neon deploy` automatically runs an env pull after applying the policy, writing the provisioned variables into `.env.local` (or `.env` if that's what the project uses). Because `neon.ts` enables the AI Gateway, that includes a freshly minted `OPENAI_API_KEY` and `OPENAI_BASE_URL` alongside `DATABASE_URL` — see `.env.example` for the full set. No separate `env pull` step is needed.
 
 ## Run locally
 
@@ -131,7 +121,7 @@ Mastra's `PostgresStore` creates its own tables (`mastra_threads`, `mastra_messa
 
 ## Chat in Mastra Studio
 
-Prefer a UI? [Mastra Studio](https://mastra.ai) gives you a local chat playground for the agent. With your env in place (the `.env.local` written by `neon link` / `neon env pull`), run:
+Prefer a UI? [Mastra Studio](https://mastra.ai) gives you a local chat playground for the agent. With your env in place (the `.env.local` written by `neon deploy`), run:
 
 ```bash
 npm run studio
@@ -147,17 +137,9 @@ Open the printed URL (e.g. `http://localhost:4112`), pick the **personal-assista
 
 Because memory supplies the conversation history, you only need to send the newest user message in each request — you don't have to resend the whole transcript.
 
-## Deploy to Neon Functions
-
-Deploy the agent as a Neon Function to your branch:
-
-```bash
-neon deploy
-```
-
 ## Test your deployed function
 
-Grab the function's invocation URL and call it:
+You already deployed the agent in the provisioning step. Grab its invocation URL and call it (redeploy after changes with `neon deploy`):
 
 ```bash
 # List the function to find its invocation URL

--- a/with-mastra/README.md
+++ b/with-mastra/README.md
@@ -57,13 +57,13 @@ If you let your agent drive this, add `--agent` to skip interactive mode.
 
 ## Provision and deploy
 
-`neon.ts` enables the AI Gateway, but `neon link` does **not** provision it — the gateway credentials don't exist until the policy is applied. `neon deploy` applies the policy (enabling the AI Gateway and deploying the agent as a Neon Function) and then pulls the resulting branch-scoped variables into `.env.local`:
+Provision the services declared in `neon.ts`:
 
 ```bash
 neon deploy
 ```
 
-> `neon deploy` automatically runs an env pull after applying the policy, writing the provisioned variables into `.env.local` (or `.env` if that's what the project uses). Because `neon.ts` enables the AI Gateway, that includes a freshly minted `OPENAI_API_KEY` and `OPENAI_BASE_URL` alongside `DATABASE_URL` — see `.env.example` for the full set. No separate `env pull` step is needed.
+> Note: `neon deploy` automatically runs an `env pull` that fetches the declared services' credentials and environment variables and writes them to a local `.env.local` file for development.
 
 ## Run locally
 

--- a/with-mastra/README.md
+++ b/with-mastra/README.md
@@ -55,8 +55,6 @@ If you let your agent drive this, add `--agent` to skip interactive mode.
 
 > The Neon AI Gateway is a Preview feature. Link to a project/region where AI Gateway early access is enabled, otherwise `neon dev` / `neon env pull` can't mint the gateway credentials.
 
-> On a brand-new project, `neon link` runs an implicit `env pull` that will warn it can't find the AI Gateway declared in `neon.ts`. That's expected — provision it in the next step, then the variables can be pulled.
-
 ## Provision the declared services
 
 `neon.ts` enables the AI Gateway, but `neon link` does **not** provision it — so the gateway credentials don't exist yet for `env pull` to read. Apply the policy first to enable it on your branch:

--- a/with-mcp/.agents/skills/neon-functions/SKILL.md
+++ b/with-mcp/.agents/skills/neon-functions/SKILL.md
@@ -1,0 +1,465 @@
+---
+name: neon-functions
+description: >-
+  Long-running, serverless Node.js HTTP functions deployed onto your Neon
+  branch, with DATABASE_URL injected automatically and compute that runs next
+  to your data. Use when a user wants to host an API, an AI agent with long
+  streaming responses, a WebSocket or server-sent-events (SSE) server, a
+  webhook handler, a Discord bot, or any request/response workload that risks
+  timing out on short, lambda-style serverless functions — and wants it to
+  branch with their database. Triggers include "serverless function", "deploy
+  an API", "long-running function", "streaming agent", "SSE server",
+  "WebSocket server", "webhook handler", "run code next to my database",
+  "function that won't time out", "Neon Functions", and "Neon Compute".
+---
+
+# Neon Functions
+
+This is a preview feature and only available in `us-east-2`. Neon Functions are long-running Node.js HTTP handlers deployed onto a Neon branch. Each function gets a public HTTPS URL, runs in the same region as your database, and — if the branch has Postgres — gets `DATABASE_URL` injected automatically. You deploy and manage them through the same Neon CLI, `neon.ts`, and API you already use.
+
+Use this skill to help the user define, run locally, deploy, and manage functions next to their database. Deliver a deployed function with its invocation URL, a working local `neonctl dev` loop, or a precise answer from the official Neon docs.
+
+## When to Use
+
+Reach for Neon Functions when the workload is a request/response handler that benefits from staying alive and staying close to the data:
+
+- **Long-running request/response flows that outlast lambda-style limits.** Agents that make several LLM calls and tool invocations per request, or image/video generation, routinely blow past the ~10–60s execution caps and short streaming windows of traditional serverless functions. Neon Functions are long-running: the handler just needs to _start_ responding within 15 minutes, and an open stream stays alive as long as bytes keep flowing. That's enough headroom for real agent workloads.
+- **Stateful streaming without bolting on Redis.** Because a function stays alive across a request, it can host an SSE endpoint or a WebSocket server and hold the connection open in-process — no external state store (Redis, etc.) needed just to keep a stream coherent. Module-scope state (a `pg` pool, an in-memory counter) persists across requests on the same isolate.
+- **Compute that must sit next to Postgres.** The function runs in the same region as the branch's database, so there are no cross-region round trips on every query. `DATABASE_URL` is injected for you.
+- **A backend that branches with your data.** Each branch runs its own version of the function at its own URL, against its own isolated database (and storage, and gateway) state. Preview deployments, CI, and dev environments each get a self-contained backend — deploying to a child never affects the parent.
+- **Webhooks, bots, and post-response work.** Webhook handlers that fan out into multiple DB writes, Discord/WebSocket bots, and fire-and-forget follow-ups via `waitUntil` (analytics, audit logs) all fit.
+
+If the workload is a pure static site, a cron/background job that needs its own lifecycle and cancellation, or something that must run outside `us-east-2` today, this isn't the right tool yet (see Timeouts and Availability below).
+
+## What It Does
+
+- **Long-running & serverless** — Built for WebSocket servers (see [WebSocket servers](#websocket-servers)), SSE endpoints (see [Server-sent events (SSE)](#server-sent-events-sse)), long agent HTTP streams, and APIs. Still scales to zero when idle.
+- **Web-standard handler** — A function is any default export with a `fetch(request)` method returning a `Response` (Workers/WinterTC-compatible). A Hono app exports exactly that shape, so `export default app` just works. Runs on Node.js 24, so all Node APIs are available.
+- **Close to your database** — Runs in the branch's region; `DATABASE_URL` injected automatically when the branch has Postgres.
+- **Branchable** — Each branch runs its own function version at its own URL against its own isolated state.
+- **Same CLI/API** — Deploy and manage via `neonctl`, `neon.ts`, or the Neon API.
+
+## Architecture: where Functions fit
+
+Neon (Functions included) is **backend primitives, not full-stack app hosting**. Host your app on **Vercel** (or Netlify, or another frontend/app host); Functions are the long-running, stateful slice of your backend that lives next to your data. They compose with that platform in two ways:
+
+- **Add a Function to a full-stack app.** Your Next.js / TanStack Start app on Vercel (or Netlify) owns UI, auth (e.g. Neon Auth), and talks directly to Neon Postgres and Object Storage. When one workload outgrows the host's short serverless limits — a WebSocket or SSE server, or a long-running agent that would time out — move just that piece onto a Neon Function. (See [Functions as an agent backend](#functions-as-an-agent-backend-nextjs-and-similar-frameworks) for the client-direct pattern.)
+- **Run the whole backend control plane on Functions.** Especially when the frontend is **client-only** — TanStack Router, React Router in client mode, and similar SPAs hosted on Vercel or Netlify — the client calls Functions **directly**. Build REST APIs and request/response agents, host **MCP servers**, and run anything stateful or that belongs close to Postgres and Object Storage.
+
+Either way, secure a Function like any standalone REST API: verify a JWT or API key at the top of the handler (see the WARNING under [Functions as an agent backend](#functions-as-an-agent-backend-nextjs-and-similar-frameworks)). Because a Function is just your backend, you can **move pieces between your host and Neon** — relocate an agent or a stateful WebSocket server onto a Function when it needs more runtime, and back if needed.
+
+## Setup
+
+Functions are declared in `neon.ts` (see the `neon` skill for the branch-first workflow and `neon.ts` basics). Add `@neondatabase/config` and declare functions under `preview.functions`, keyed by **slug**:
+
+```typescript
+// neon.ts
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  preview: {
+    functions: {
+      todos: {
+        // slug: ^[a-z0-9]{1,20}$ — lowercase letters/digits, no hyphens
+        name: "todo api", // display label only
+        source: "src/index.ts", // entry file, relative to neon.ts
+      },
+    },
+  },
+});
+```
+
+The slug is the function's permanent identity (it appears in the invocation URL and CLI commands) and can't be changed after the first deploy. Use `name` for a human-readable label.
+
+A minimal function — a Hono app that queries the branch's Postgres via the injected `DATABASE_URL`:
+
+```typescript
+// src/index.ts
+import { Hono } from "hono";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { parseEnv } from "@neondatabase/env/v1";
+import config from "../neon";
+import { todos } from "./db/schema";
+
+const env = parseEnv(config);
+const pool = new Pool({ connectionString: env.postgres.databaseUrl, max: 5 });
+const db = drizzle(pool);
+
+const app = new Hono();
+app.get("/", (c) => c.text("Neon + Hono + Drizzle"));
+app.post("/todos", async (c) => {
+  const { text } = await c.req.json<{ text: string }>();
+  const [row] = await db.insert(todos).values({ text }).returning();
+  return c.json(row, 201);
+});
+app.get("/todos", async (c) => c.json(await db.select().from(todos)));
+
+export default app;
+```
+
+This is the `with-hono` example, verified end to end. Create the `pg` pool at module scope (reused across requests on the same isolate) and keep `max` small (e.g. 5), since each isolate keeps its own pool.
+
+`parseEnv(config)` requires _every_ variable the config implies. A function that only talks to Postgres over the pooled URL can scope it to just that key — `parseEnv` then validates and returns only what you asked for (the keys autocomplete from your `neon.ts`):
+
+```typescript
+const { postgres } = parseEnv(config, ["DATABASE_URL"]); // not the unpooled URL, auth, etc.
+const pool = new Pool({ connectionString: postgres.databaseUrl, max: 5 });
+```
+
+## Develop locally and deploy
+
+```bash
+neonctl dev      # serves every function in neon.ts with hot reload; injects DATABASE_URL & friends
+neonctl deploy   # bundles with esbuild, uploads, and applies neon.ts to the linked branch
+```
+
+To deploy a single function without `neon.ts`: `neonctl functions deploy <slug> --path . --entry src/index.ts`. Retrieve the public URL with `neonctl functions get <slug>` (the `invocation_url` field, of the form `https://<branch_id>-<slug>.compute.c-1.us-east-2.aws.neon.tech`). Manage with `neonctl functions list|get|delete`.
+
+When `neonctl checkout` _creates_ a new branch and a `neon.ts` is present, it applies the policy automatically — deploying the function to the fresh branch. Checking out an existing branch does not re-deploy; run `neonctl deploy` explicitly.
+
+## Neon Infrastructure as Code (`neon.ts`)
+
+The `preview.functions` block from [Setup](#setup) is part of `neon.ts`, Neon's infrastructure-as-code file — one TypeScript file declares every function (its `source`, display `name`, and `env`) alongside any other branch services, in version control (see the `neon` skill for the full reference). Treat it like Terraform for your branch:
+
+```bash
+neonctl config status   # print the branch's live config (deployed functions)
+neonctl config plan     # dry-run diff of what apply would change
+neonctl config apply    # bundle + deploy the declared functions  (neonctl deploy is an alias)
+```
+
+Functions are **branch-scoped**: each branch runs its own deployment at its own URL. When a `neon.ts` is present, `neonctl checkout` applies the policy as it _creates_ a branch, so a fresh preview/CI branch comes up with the function already deployed. Checking out an _existing_ branch doesn't redeploy — run `neonctl deploy` to apply changes.
+
+Per-branch deploy tuning (e.g. `runtime`) lives in the `branch` closure, keyed by slug, so it can vary by branch without changing which functions exist:
+
+```typescript
+export default defineConfig({
+  preview: {
+    functions: { todos: { name: "todo api", source: "src/index.ts" } },
+  },
+  branch: (branch) => ({
+    preview: { functions: { todos: { runtime: "nodejs24" } } },
+  }),
+});
+```
+
+## Environment variables
+
+Neon injects branch-scoped connection strings and service URLs at runtime — you don't declare these or pass them at deploy time:
+
+| Variable                | Notes                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------- |
+| `NEON_BRANCH`           | The branch **name** (e.g. `main`, `preview/foo`). Injected on every branch, including the default. |
+| `DATABASE_URL`          | Pooled connection string. Use for most queries. Present only if the branch has Postgres. |
+| `DATABASE_URL_UNPOOLED` | Direct connection. Use for migrations, `LISTEN`/`NOTIFY`, multi-round-trip transactions. |
+| `NEON_AUTH_BASE_URL`    | Present when Neon Auth is enabled on the branch.                                         |
+| `NEON_DATA_API_URL`     | Present when the Data API is enabled on the branch.                                      |
+
+Object storage (`AWS_*`) and AI Gateway (`OPENAI_*`, `NEON_AI_GATEWAY_*`) vars are also injected when those services are declared — see the `neon-object-storage` and `neon-ai-gateway` skills.
+
+`neonctl env pull` / `neon-env run` / `neonctl dev` emit `NEON_BRANCH` (and the connection strings) into your local dev environment too, so local runs mirror the deployed runtime.
+
+**Your own secrets** are per-deployment. Set them with `--env KEY=VALUE` on `neonctl functions deploy` (repeatable; `--env KEY=` deletes a key, unmentioned keys carry over), or declare them in `neon.ts` under the function's `env` (resolved at deploy time, so read from `process.env` to avoid hardcoding):
+
+```typescript
+functions: {
+  todos: {
+    name: "todo api",
+    source: "src/index.ts",
+    env: { OPENAI_API_KEY: process.env.OPENAI_API_KEY! },
+  },
+}
+```
+
+Load a `.env` before deploy with `neonctl deploy --env .env.production`. Pull the branch's Neon-managed vars onto disk for local dev with `neonctl env pull` (`link`/`checkout` do this automatically; pass `--no-env-pull` to skip and use `neon-env run -- <cmd>` for runtime injection). Limits: ≤1,000 vars, ≤64 KiB total, and the `NEON_` prefix is reserved.
+
+## Connecting to Postgres
+
+When the branch has Postgres, Neon **injects the connection strings at runtime** — you don't declare them, pass them at deploy time, or hardcode anything. The two you'll use:
+
+- `DATABASE_URL` — **pooled** connection string (routed through Neon's connection pooler). Use it for normal request/response query traffic. Kept un-prefixed because every Postgres ORM (Drizzle, Prisma, Knex, …) reads `DATABASE_URL` by default.
+- `DATABASE_URL_UNPOOLED` — **direct** connection string to the same database. Use it for migrations, `LISTEN`/`NOTIFY`, and long multi-statement transactions.
+
+**Use Drizzle (or another ORM) on top of node-postgres (`pg`)** for queries and schema management — not Neon's serverless driver. Functions are long-running and reuse an isolate across many requests, so a persistent `pg` pool is the right fit; the serverless driver's HTTP transport is meant for fully isolated, lambda-style runtimes.
+
+Create the connection pool **once at module scope** and reuse it across requests — don't open a connection per request:
+
+```typescript
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+// Created once per isolate; reused by every request that isolate handles.
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+const db = drizzle(pool);
+```
+
+**Pooling is recommended because an isolate is reused across many requests** (and several requests can be in flight on the same isolate at once — see [Timeouts and runtime limits](#timeouts-and-runtime-limits)). A module-scope pool is opened once on cold start and then shared by every subsequent request that isolate serves, so you amortize connection setup instead of paying it on every request and you avoid exhausting Postgres connections under load.
+
+Keep `max` small (e.g. `5`): each isolate keeps its own pool, so total connections to Postgres scale with the number of live isolates. Drain the pool when the runtime evicts the isolate so connections close cleanly:
+
+```typescript
+process.on("SIGINT", () => {
+  pool.end().then(() => process.exit(0));
+});
+```
+
+> Reading `process.env.DATABASE_URL` directly works everywhere. The `with-hono` example in [Setup](#setup) instead uses `@neondatabase/env/v1`'s `parseEnv(config)` to read the same value in a typed, validated way — either is fine.
+
+## WebSocket servers
+
+A WebSocket server is the canonical Functions workload: a long-running handler holds connections open in-process, with no external state store needed to keep a stream coherent. Because a function is a real Node.js process (not a lambda), the WebSocket handshake works the way it does in any Node server — the [`ws`](https://github.com/websockets/ws) library upgrades the socket, and the connection stays alive as long as bytes flow (15-minute heartbeat, see [Timeouts](#timeouts-and-runtime-limits)).
+
+**The return signature is the whole trick.** A function's default export is normally `{ fetch }`. To also accept WebSockets, export an `upgrade` method alongside it — the runtime routes plain HTTP to `fetch` and the WebSocket handshake to `upgrade`:
+
+```typescript
+export default {
+  fetch(request: Request): Response | Promise<Response> { /* HTTP */ },
+  async upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) { /* WS handshake */ },
+};
+```
+
+**Simple example** — raw `ws`, no framework, with auth. Browsers can't set headers on a WebSocket, so authenticate with a `?token=` query param (verify it the same way as the [agent backend](#functions-as-an-agent-backend-nextjs-and-similar-frameworks): `jwtVerify` against your JWKS) before accepting the connection:
+
+```typescript
+// src/index.ts
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { WebSocketServer, type WebSocket } from "ws";
+
+const clients = new Set<WebSocket>();
+const wss = new WebSocketServer({ noServer: true });
+
+export default {
+  // Plain HTTP (health checks, REST) is handled by fetch.
+  fetch: () => new Response("WebSocket endpoint — connect with ?token=<jwt>"),
+
+  // The runtime hands the WebSocket handshake to upgrade().
+  async upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const identity = await verifyToken(url.searchParams.get("token")); // reject if invalid
+    if (!identity) {
+      socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      clients.add(ws);
+      ws.on("close", () => clients.delete(ws));
+      ws.on("message", (data) => broadcast(data.toString())); // see fan-out below
+    });
+  },
+};
+```
+
+**Hono variant.** If you only need Hono for the HTTP side and are happy driving `ws` yourself, just swap `fetch` in the simple example for `app.fetch` and keep the raw `upgrade` — Hono serves routing/middleware, `ws` serves the socket.
+
+To instead declare WebSocket routes _inside_ the Hono app — `app.get("/ws", upgradeWebSocket(...))` with the standard `onOpen`/`onMessage`/`onClose` lifecycle — you need an adapter that bridges Hono's `upgradeWebSocket()` helper to Neon's `upgrade(req, socket, head)`. Hono ships adapters for Cloudflare/Deno/Bun/Node, but **none for Neon**, and the Node one (`@hono/node-ws`) is deprecated and assumes it owns the HTTP server. [references/hono-websockets.md](references/hono-websockets.md) has a small self-contained `createNeonWebSocket(app)` adapter to copy in — it depends only on `hono` and `ws` (no deprecated package; adapted from `@hono/node-ws`, MIT) and returns a ready-to-export `{ fetch, upgrade }` handler. Usage is idiomatic Hono, and because the handshake routes through `app.request`, **auth is just normal route middleware**:
+
+```typescript
+// src/index.ts
+import { Hono } from "hono";
+import { createNeonWebSocket } from "./hono-ws";
+
+const app = new Hono();
+const { upgradeWebSocket, handler } = createNeonWebSocket(app);
+
+app.get(
+  "/ws",
+  async (c, next) => {
+    if (!(await verifyToken(c.req.query("token")))) return c.text("Unauthorized", 401);
+    await next();
+  },
+  upgradeWebSocket(() => ({
+    onOpen: (_evt, ws) => ws.send("welcome"),
+    onMessage: (evt, ws) => ws.send(`echo: ${evt.data}`),
+    onClose: () => console.log("disconnected"),
+  })),
+);
+
+export default handler; // Neon's { fetch, upgrade } contract
+```
+
+> Don't put header-modifying middleware (e.g. CORS) on an `upgradeWebSocket` route — the helper rewrites headers internally and will throw. The [fan-out](#fan-out-across-isolates-do-not-skip-this) and [reconnect](#client-must-reconnect) guidance below applies unchanged.
+
+### Heartbeat (keep the socket alive)
+
+A connection stays open **only while bytes flow**: Neon evicts a silent stream after 15 minutes ([Timeouts and runtime limits](#timeouts-and-runtime-limits)), and intermediary proxies / load balancers are usually far stricter (often tens of seconds). Don't rely on the app being chatty enough — send a periodic ping from the server so the socket never goes quiet. `ws.ping()` sends a WebSocket ping frame and the browser answers with a pong automatically, so there's no client code to write:
+
+```typescript
+const HEARTBEAT_MS = 25_000; // comfortably under proxy idle timeouts
+
+const beat = setInterval(() => {
+  for (const ws of clients) if (ws.readyState === ws.OPEN) ws.ping();
+}, HEARTBEAT_MS);
+beat.unref?.();
+
+process.on("SIGINT", () => clearInterval(beat));
+```
+
+(With the Hono `upgradeWebSocket` helper you don't hold the raw socket, so send an application-level keepalive instead — e.g. `ws.send("ping")` on the same interval, ignored by the client.)
+
+### Fan-out across isolates (do not skip this)
+
+Under load the runtime runs **several isolates in parallel, each with its own copy of module state** — so each isolate has its own `clients` set. Broadcasting only to the local set means a client connected to isolate A never sees a message sent by a client on isolate B. The chat would silently fracture.
+
+Fan out across every isolate with **Postgres `LISTEN`/`NOTIFY`**: each isolate `LISTEN`s on a channel over a dedicated **unpooled** connection, and broadcasting means `NOTIFY` (so every isolate, including the sender's, re-broadcasts to its own sockets). This is also why message state must live in Postgres, not module memory — module state doesn't survive eviction.
+
+```typescript
+import { Pool, Client } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+const CHANNEL = "chat_events";
+
+// One dedicated DIRECT connection per isolate, just to receive events.
+// Use DATABASE_URL_UNPOOLED — LISTEN needs a real session, not a pooled one.
+const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
+listener.on("notification", (msg) => {
+  if (!msg.payload) return;
+  for (const ws of clients) if (ws.readyState === ws.OPEN) ws.send(msg.payload);
+});
+
+// Broadcast by NOTIFYing through the pool — every isolate's listener fires.
+function broadcast(event: unknown) {
+  return pool.query("SELECT pg_notify($1, $2)", [CHANNEL, JSON.stringify(event)]);
+}
+
+// Drain both on eviction so connections close cleanly.
+process.on("SIGINT", () => {
+  Promise.allSettled([pool.end(), listener.end()]).then(() => process.exit(0));
+});
+```
+
+### Client must reconnect
+
+Idle functions are evicted (and isolates restart for operational reasons), so a client's socket **will** drop — treat reconnection as normal, not exceptional. Reconnect with exponential backoff, capped, and **re-mint a fresh token on every attempt** (tokens are short-lived, so a stale one fails the `upgrade` auth check):
+
+```typescript
+let closed = false, retry = 0, timer: ReturnType<typeof setTimeout>;
+
+async function connect() {
+  if (closed) return;
+  const token = await getToken(); // re-mint each attempt; short-lived
+  const ws = new WebSocket(`${WS_URL}?token=${encodeURIComponent(token)}`);
+  ws.onopen = () => { retry = 0; };          // reset backoff on success
+  ws.onmessage = (e) => { /* apply the event */ };
+  ws.onclose = () => {
+    if (!closed) timer = setTimeout(connect, Math.min(1000 * 2 ** retry++, 15000));
+  };
+  ws.onerror = () => ws.close();             // let onclose drive the retry
+}
+connect();
+```
+
+A full, verified build of this pattern — Hono `fetch` + `ws` `upgrade`, JWT auth over `?token=`, `LISTEN`/`NOTIFY` fan-out, client backoff, plus image uploads and an in-function moderation agent — is the `with-realtime-chat` example in [`neondatabase/examples`](https://github.com/neondatabase/examples/tree/main/with-realtime-chat).
+
+## Server-sent events (SSE)
+
+When you only need **server → client** streaming (live counters, notifications, progress, token streams), SSE is simpler than a WebSocket and needs no `upgrade` method or extra library: a plain `fetch` handler returns a `Response` whose body is a `ReadableStream` with `Content-Type: text/event-stream`, and the runtime holds it open as long as bytes flow. The browser consumes it with `EventSource`, which **reconnects on its own** — so there's no client backoff to write.
+
+```typescript
+// src/index.ts — minimal SSE endpoint
+const encoder = new TextEncoder();
+export default {
+  fetch: () =>
+    new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("data: hello\n\n"));
+          const t = setInterval(() => controller.enqueue(encoder.encode(": ping\n\n")), 25_000);
+          return () => clearInterval(t); // fires when the client disconnects
+        },
+      }),
+      { headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache, no-transform" } },
+    ),
+};
+```
+
+The same rules as WebSockets apply. **Heartbeat:** a stream stays open only while bytes flow — Neon's window is 15 minutes ([Timeouts and runtime limits](#timeouts-and-runtime-limits)) but proxies are usually far stricter, so emit a `: ping\n\n` comment every ~25–30s (shown above) to keep idle streams from being dropped. Keep state in Postgres, and fan out across isolates with [`LISTEN`/`NOTIFY`](#fan-out-across-isolates-do-not-skip-this) (hold a `Set` of stream controllers and `enqueue` to each). `EventSource` is GET-only and can't set headers, so authenticate with a `?token=` query param or cookie, exactly like the WebSocket case. [references/sse.md](references/sse.md) has the full pattern — Hono variant, cross-isolate fan-out, wire format, client, and caveats — and a verified end-to-end build is the `with-realtime-sse` example in [`neondatabase/examples`](https://github.com/neondatabase/examples/tree/main/with-realtime-sse).
+
+## Integrations and observability
+
+A function is a long-lived Node.js process running a web-standard request/response handler, so standard Node integration SDKs work unchanged — initialize them once at module load, gated on an env var so local dev and unconfigured branches stay a no-op, and pass secrets via `--env` or `neon.ts` `env`. For wiring up **Sentry** error monitoring across the HTTP framework, the function runtime, and an agent's own caught/fallback failures (the long-running case Functions target), see [references/sentry.md](references/sentry.md). For running a **Mastra** agent on a function and shipping its traces to a **Mastra Studio (Mastra Cloud)** project for observability, see [references/mastra-studio.md](references/mastra-studio.md).
+
+## Timeouts and runtime limits
+
+Functions are long-running but **still serverless** — they are a request/response runtime, not a background job runner. The hard limits:
+
+- **Time to first byte: 15 minutes.** Your handler must _begin_ returning a response within 15 minutes of receiving a request. Most handlers finish in seconds; the 15-minute ceiling exists so agent workloads like image/video generation have room.
+- **Heartbeat: 15 minutes.** Open WebSocket/SSE connections stay alive as long as data flows. The timeout only fires when a connection goes silent — send at least one byte every 15 minutes to keep a quiet stream alive.
+- **`waitUntil`: 15 minutes.** Work registered with `waitUntil` keeps the invocation alive after the response is sent, up to 15 minutes — for cleanup like analytics writes and audit logs, **not** a background job runner. (`waitUntil` from `@neondatabase/functions/v1` is currently a stub during the preview.)
+- **Idle eviction.** With no active connections the platform shuts the function down; it may also evict/restart for operational reasons (active functions can run for hours first). Treat eviction like a process restart — WebSocket/SSE clients must reconnect. The platform sends `SIGINT` before evicting, so register a handler to drain gracefully:
+
+```typescript
+process.on("SIGINT", () => {
+  pool.end().then(() => process.exit(0));
+});
+```
+
+- **Runtime:** Node.js 24, memory fixed at 2048 MiB during the preview. Slugs must match `^[a-z0-9]{1,20}$`. **An isolate is reused across many requests** — multiple requests can be in flight on the same isolate at once (interleaved on Node's single-threaded event loop), and under load the runtime runs several isolates in parallel, each with its own copy of module state. State held in module scope is therefore per-isolate (shared by every request that isolate handles) and in-memory only — persist anything that must survive eviction in Postgres. This reuse is exactly why you create a connection pool once at module scope rather than per request (see [Connecting to Postgres](#connecting-to-postgres)).
+
+## Functions as an agent backend (Next.js and similar frameworks)
+
+A Neon Function is a great home for an AI agent precisely because it **doesn't time out** the way lambda-style serverless does (15-minute budget, see above). But that advantage disappears the moment you **proxy the agent stream through your web app's backend** — a Next.js route handler, Remix/SvelteKit/Nuxt action, etc. hosted on Vercel, Netlify, Cloudflare, and the like. Those platforms cap serverless/edge execution at short windows (often ~10–60s, sometimes up to ~300s), so a long agent or image/video generation stream gets cut off mid-response even though the Neon Function would happily keep going.
+
+**The fix: call the function directly from the client.** Don't route the long request through your app server.
+
+```
+Browser ──(Authorization: Bearer <JWT>)──▶  Neon Function (agent)   ✅ no host timeout
+Browser ──▶ your app backend ──▶ Neon Function                       ❌ host cuts the stream
+```
+
+- Mint a **short-lived JWT** on your app backend (e.g. better-auth's `jwt` plugin, NextAuth, or your own signer) — that call is fast and well within host limits.
+- Hand the token to the client and have it call the Neon Function **directly** (cross-origin), e.g. with the Vercel AI SDK: `new DefaultChatTransport({ api: NEON_FUNCTION_URL, fetch })` where `fetch` attaches `Authorization: Bearer <token>`. Your app server is never in the path of the long stream.
+- Add **CORS** so the browser can reach it (handle `OPTIONS`, set `Access-Control-Allow-Origin`/`-Headers`).
+
+> [!WARNING]
+> A Neon Function has a **public HTTPS URL — it is reachable by anyone.** A direct client→function call means there is no app backend in front of it to gate access, so **you must authenticate the function yourself.** Verify a JWT (e.g. against your app's JWKS), check a shared secret / API key, or validate a session token at the top of the handler and reject anything else. Never deploy an unauthenticated agent.
+
+```typescript
+// src/index.ts — verify the caller before doing any work
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const jwks = createRemoteJWKSet(new URL(`${process.env.AUTH_BASE_URL}/api/auth/jwks`));
+
+export default {
+  async fetch(request: Request) {
+    if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: cors(request) });
+
+    const auth = request.headers.get("authorization");
+    if (!auth?.toLowerCase().startsWith("bearer ")) {
+      return new Response("Unauthorized", { status: 401, headers: cors(request) });
+    }
+    try {
+      const { payload } = await jwtVerify(auth.slice(7), jwks, {
+        issuer: process.env.AUTH_BASE_URL,
+        audience: process.env.AUTH_BASE_URL,
+      });
+      const userId = payload.sub; // scope the agent to this user
+      // ... run the agent, return result.toUIMessageStreamResponse({ headers: cors(request) })
+    } catch {
+      return new Response("Unauthorized", { status: 401, headers: cors(request) });
+    }
+  },
+};
+```
+
+Pass the JWKS/issuer URL to the function via its `env` (see Environment variables). Persist anything you need to keep (generated images, history) in Postgres — module state doesn't survive eviction.
+
+## Availability
+
+Neon Functions is a preview (early access) feature available only on new projects in the `us-east-2` region. Confirm the user's Neon project is a new project in `us-east-2`; it can't be enabled on existing projects. Functions usage isn't billed during the private preview. If the user does not yet have access, point them to the private beta sign-up: https://neon.com/blog/were-building-backends#access
+
+## Neon Documentation
+
+The Neon documentation is the source of truth and Functions is evolving rapidly, so always verify against the official docs. Any doc page can be fetched as markdown by appending `.md` to the URL or by requesting `Accept: text/markdown`. Find the right page from the docs index (https://neon.com/docs/llms.txt) and the changelog announcements.
+
+## Further reading
+
+- https://neon.com/docs/compute/functions/overview.md
+- https://neon.com/docs/compute/functions/get-started.md
+- https://neon.com/docs/compute/functions/deploy.md
+- https://neon.com/docs/compute/functions/environment-variables.md
+- https://neon.com/docs/compute/functions/reference/neon-ts.md
+- https://neon.com/docs/compute/functions/reference/runtime-limits.md
+- https://neon.com/docs/compute/functions/preview-access.md

--- a/with-mcp/.agents/skills/neon-functions/references/hono-websockets.md
+++ b/with-mcp/.agents/skills/neon-functions/references/hono-websockets.md
@@ -1,0 +1,145 @@
+# Hono WebSocket helper on Neon Functions
+
+Neon Functions accept WebSockets via a `{ fetch, upgrade }` default export, where `upgrade(req, socket, head)` is the raw Node handshake (see the [WebSocket servers](../SKILL.md#websocket-servers) section). That works directly with the `ws` library. If you'd rather declare WebSocket routes _inside_ a Hono app — `app.get("/ws", upgradeWebSocket(...))` with the standard `onOpen`/`onMessage`/`onClose` lifecycle — you need an adapter.
+
+## Why an adapter (and why not `@hono/node-ws`)
+
+Hono's `upgradeWebSocket()` is runtime-agnostic at the route layer, but the actual handshake is done by a per-runtime adapter (`hono/cloudflare-workers`, `hono/deno`, `hono/bun`, `@hono/node-server`). **There is no adapter for Neon.** The Node one, `@hono/node-ws`, is **deprecated** and its replacement assumes it owns the HTTP server (`serve({ websocket })`) — which Neon's runtime does instead.
+
+So vendor the small adapter below. It depends only on `hono` and `ws` (no deprecated package), and is adapted from `@hono/node-ws` (MIT). Instead of attaching to an `http.Server`'s `'upgrade'` event, it returns a ready-to-export `{ fetch, upgrade }` handler that matches Neon's contract.
+
+## The adapter
+
+```typescript
+// src/hono-ws.ts — bridges Hono's upgradeWebSocket() to Neon's { fetch, upgrade }.
+import { STATUS_CODES, type IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import type { Hono } from "hono";
+import { WSContext, defineWebSocketHelper } from "hono/ws";
+import { WebSocketServer, type WebSocket } from "ws";
+
+type Wire = (ws: WebSocket) => void;
+
+export function createNeonWebSocket(app: Hono, baseUrl = "http://localhost") {
+  const wss = new WebSocketServer({ noServer: true });
+  // Correlate a handshake to its route handler via the per-request env object identity.
+  const pending = new Map<unknown, Wire>();
+
+  const upgradeWebSocket = defineWebSocketHelper(async (c, events, options) => {
+    if (c.req.header("upgrade")?.toLowerCase() !== "websocket") return;
+    const url = c.req.url;
+    pending.set(c.env, (ws) => {
+      const onError = options?.onError ?? ((e: unknown) => console.error(e));
+      const ctx = new WSContext<WebSocket>({
+        send: (data, opts) => ws.send(data, { compress: opts?.compress }),
+        close: (code, reason) => ws.close(code, reason),
+        raw: ws,
+        url,
+        protocol: ws.protocol,
+        get readyState() {
+          return ws.readyState;
+        },
+      });
+      try {
+        events.onOpen?.(new Event("open"), ctx);
+      } catch (e) {
+        onError(e);
+      }
+      ws.on("message", (data, isBinary) => {
+        for (const chunk of Array.isArray(data) ? data : [data]) {
+          try {
+            const payload = isBinary
+              ? chunk instanceof ArrayBuffer
+                ? chunk
+                : chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength)
+              : chunk.toString("utf-8");
+            events.onMessage?.(new MessageEvent("message", { data: payload }), ctx);
+          } catch (e) {
+            onError(e);
+          }
+        }
+      });
+      ws.on("close", (code, reason) => {
+        try {
+          events.onClose?.(new CloseEvent("close", { code, reason: reason.toString() }), ctx);
+        } catch (e) {
+          onError(e);
+        }
+      });
+      // Node 24 has no global ErrorEvent; a browser's ws.onerror gets a plain Event anyway.
+      ws.on("error", (error) => {
+        onError(error);
+        try {
+          events.onError?.(new Event("error"), ctx);
+        } catch (e) {
+          onError(e);
+        }
+      });
+    });
+    return new Response();
+  });
+
+  const handler = {
+    fetch: (request: Request) => app.fetch(request),
+    async upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+      const url = new URL(req.url ?? "/", baseUrl);
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (value) headers.append(key, Array.isArray(value) ? value[0] : value);
+      }
+      // The env object identity links this request back to the route handler above.
+      const env = { incoming: req, outgoing: undefined };
+      const response = await app.request(url, { headers }, env);
+      const wire = pending.get(env);
+      pending.delete(env);
+      if (!wire) {
+        socket.end(`HTTP/1.1 ${response.status} ${STATUS_CODES[response.status] ?? ""}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`);
+        return;
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => wire(ws));
+    },
+  };
+
+  return { upgradeWebSocket, handler };
+}
+```
+
+How it works: the `upgrade` handler runs the handshake request through `app.request(...)` so Hono's router matches the `upgradeWebSocket` route; the helper registers a `wire` callback keyed by the per-request `env` object; if a route matched, `wss.handleUpgrade` accepts the socket and `wire` attaches the lifecycle handlers, otherwise the socket is closed with the route's status (e.g. 401/404).
+
+## Usage
+
+Because the handshake is routed through `app.request`, **auth and other gating are just normal Hono middleware on the route** — verify the `?token=` and return 401 before the upgrade:
+
+```typescript
+// src/index.ts
+import { Hono } from "hono";
+import { createNeonWebSocket } from "./hono-ws";
+
+const app = new Hono();
+const { upgradeWebSocket, handler } = createNeonWebSocket(app);
+
+app.get("/", (c) => c.text("ok"));
+
+app.get(
+  "/ws",
+  async (c, next) => {
+    const identity = await verifyToken(c.req.query("token")); // your JWT check
+    if (!identity) return c.text("Unauthorized", 401);
+    await next();
+  },
+  upgradeWebSocket(() => ({
+    onOpen: (_evt, ws) => ws.send("welcome"),
+    onMessage: (evt, ws) => ws.send(`echo: ${evt.data}`),
+    onClose: () => console.log("disconnected"),
+  })),
+);
+
+export default handler; // Neon's { fetch, upgrade } contract
+```
+
+## Caveats
+
+- **No header-modifying middleware on the WS route.** Per [Hono's docs](https://hono.dev/docs/helpers/websocket), middleware that changes headers (e.g. CORS) on an `upgradeWebSocket` route throws ("can't modify immutable headers"), because the helper rewrites headers internally. Auth middleware that only reads the query/headers and returns 401 is fine.
+- **Send a heartbeat.** A socket is dropped once it goes silent — Neon's window is 15 minutes ([Timeouts](../SKILL.md#timeouts-and-runtime-limits)), but intermediary proxies are usually far stricter (tens of seconds). Send a keepalive every ~25–30s so the connection never goes quiet. With the raw `ws` socket use `ws.ping()` (the browser auto-replies with a pong); through this helper you don't hold the raw socket, so send an app-level `ws.send("ping")` the client ignores instead. See [Heartbeat](../SKILL.md#heartbeat-keep-the-socket-alive).
+- **Fan-out and reconnect still apply.** This adapter only covers the per-isolate handshake. For a genuinely shared chat across isolates, broadcast with Postgres `LISTEN`/`NOTIFY`, and have clients reconnect with backoff — see [Fan-out across isolates](../SKILL.md#fan-out-across-isolates-do-not-skip-this) and [Client must reconnect](../SKILL.md#client-must-reconnect).
+- **Node-only globals.** Relies on `Event`, `MessageEvent`, and `CloseEvent` (all present on Neon's Node 24 runtime). `ErrorEvent` is intentionally avoided since it isn't a Node global.

--- a/with-mcp/.agents/skills/neon-functions/references/mastra-studio.md
+++ b/with-mcp/.agents/skills/neon-functions/references/mastra-studio.md
@@ -1,0 +1,132 @@
+# Mastra agents with Mastra Studio observability
+
+A Neon Function is a long-lived Node.js 24 process, which makes it a natural host for a [Mastra](https://mastra.ai) agent: the agent keeps running for the life of the request, and you point its model at the Neon AI Gateway so there are no extra provider keys. You can keep **running the agent on Neon Functions** while shipping its traces to a **Mastra Studio (Mastra Cloud) project** for observability — the agent runs on Neon, the traces are viewable in Mastra.
+
+The shape mirrors any other Node integration (see `references/sentry.md`): instantiate at module load, gate on env vars so local dev and unconfigured branches stay a no-op, and pass secrets at deploy time via `neon.ts`. `@mastra/core` and `@mastra/observability` bundle cleanly through `neonctl deploy`'s esbuild with no extra config.
+
+## 1. Define the agent against the Neon AI Gateway
+
+Use the gateway's **MLflow (chat-completions) dialect**, which serves every provider (OpenAI, Anthropic, …) — derive it from the injected `aiGateway.baseUrl` (see the `neon-ai-gateway` skill). `parseEnv` reads the injected gateway credentials from your `neon.ts`.
+
+```typescript
+// src/mastra/agents/pricing.ts
+import { Agent } from "@mastra/core/agent";
+import { parseEnv } from "@neondatabase/env/v1";
+import config from "../../../neon";
+
+const env = parseEnv(config);
+const gatewayUrl = env.aiGateway.baseUrl.replace("/openai/v1", "/mlflow/v1");
+
+export const pricingAgent = new Agent({
+  id: "pricing-analyst",
+  name: "pricing-analyst",
+  instructions: "You are a meticulous pricing analyst. …",
+  model: { id: "neon/gpt-5-mini", url: gatewayUrl, apiKey: env.aiGateway.apiKey },
+});
+```
+
+## 2. Wire observability to Mastra Studio
+
+The `MastraPlatformExporter` (from `@mastra/observability`) sends traces to a Mastra Studio project. It reads `MASTRA_PLATFORM_ACCESS_TOKEN` and `MASTRA_PROJECT_ID` from the environment.
+
+Gotcha: `Observability` requires **at least one exporter** — passing an empty `exporters` array throws `OBSERVABILITY_INVALID_INSTANCE_CONFIG`. So omit the `observability` option entirely until the platform creds are present, keeping the app runnable before the Mastra project exists (and in local dev).
+
+```typescript
+// src/mastra/index.ts
+import { Mastra } from "@mastra/core/mastra";
+import { Observability, MastraPlatformExporter } from "@mastra/observability";
+import { pricingAgent } from "./agents/pricing";
+
+const platformReady = Boolean(
+  process.env.MASTRA_PLATFORM_ACCESS_TOKEN && process.env.MASTRA_PROJECT_ID,
+);
+
+const observability = platformReady
+  ? new Observability({
+      configs: {
+        default: { serviceName: "my-app", exporters: [new MastraPlatformExporter()] },
+      },
+    })
+  : undefined;
+
+export const mastra = new Mastra({
+  agents: { pricingAgent },
+  ...(observability ? { observability } : {}),
+});
+```
+
+Agents must be **registered on the `Mastra` instance** (the `agents` map) for their `.generate()` / `.stream()` calls to be traced. Call them via `mastra.getAgent("pricingAgent")`.
+
+## 3. Structured output through the gateway
+
+The gateway does not enforce **native** structured output, so a bare `structuredOutput: { schema }` can come back missing fields (e.g. a nested `meta` object), failing Zod validation. Set `jsonPromptInjection: true` so Mastra injects the schema into the prompt and the model returns the full shape:
+
+```typescript
+const agent = mastra.getAgent("pricingAgent");
+const result = await agent.generate(prompt, {
+  structuredOutput: { schema: myZodSchema, jsonPromptInjection: true },
+  abortSignal: AbortSignal.timeout(70_000), // bound each attempt; the gateway has an upstream timeout
+});
+const data = result.object; // validated against myZodSchema
+```
+
+For resilience, register a second agent on a different model (e.g. `neon/claude-haiku-4-5`) and fall back to it if the primary attempt throws — the same provider-fallback pattern works because both are reachable on the MLflow dialect.
+
+## 4. Create the Mastra project + token with the CLI
+
+Install the Mastra CLI (`npm i -g mastra`) and authenticate. Project/token creation needs a **live login session**:
+
+```bash
+mastra auth login        # opens a browser; required before the steps below
+mastra auth whoami       # shows your user + org id (org_…)
+```
+
+- **Access token (non-interactive):** `mastra auth tokens create <name>` prints a one-time secret (`sk_…`). This is your `MASTRA_PLATFORM_ACCESS_TOKEN`.
+- **Project:** the interactive `mastra studio projects create` TUI is hard to script. Instead, register the project as part of a Studio deploy, which is non-interactive with `-y` and writes the project id to `.mastra-project.json`:
+
+```bash
+mastra studio deploy --org org_xxx --project my-app -y
+# → .mastra-project.json: { "projectId": "…", "projectName": "my-app", "organizationId": "org_…" }
+```
+
+Use that `projectId` as `MASTRA_PROJECT_ID`.
+
+Two gotchas:
+
+- **Don't set `MASTRA_API_TOKEN` in the env for project/deploy commands** — it makes the CLI report `No organizations found`. Rely on the interactive login session instead.
+- If you keep multiple env files (e.g. `.env.deploy` and `.env.local`), `studio deploy` errors with `Multiple env files found`; pass `--env-file <file>` to disambiguate.
+
+## 5. Pass the creds via `neon.ts` (third-party env)
+
+Neon-injected vars (`DATABASE_URL`, `OPENAI_*`, AI Gateway) are automatic. Declare only third-party vars under the function's `env`, resolved from `process.env` at deploy time:
+
+```typescript
+// neon.ts
+functions: {
+  myapp: {
+    name: "my app",
+    source: "src/index.ts",
+    env: {
+      MASTRA_PROJECT_ID: process.env.MASTRA_PROJECT_ID ?? "",
+      MASTRA_PLATFORM_ACCESS_TOKEN: process.env.MASTRA_PLATFORM_ACCESS_TOKEN ?? "",
+    },
+  },
+}
+```
+
+Load the values from a git-ignored file at deploy time:
+
+```bash
+neonctl deploy --env .env.deploy
+```
+
+## 6. Verify
+
+Send a request that exercises the agent, then open the Mastra Studio project's **Observability / Traces** view — you'll see the agent run (model calls, latency, token usage) under the `serviceName` you configured. Only `SPAN_ENDED` events are exported, buffered and flushed periodically, so a trace appears a few seconds after the agent run completes.
+
+## Further reading
+
+- https://mastra.ai/docs/observability/tracing/exporters/cloud
+- https://mastra.ai/reference/observability/tracing/exporters/mastra-platform-exporter
+- https://mastra.ai/docs/agents/structured-output
+- Neon AI Gateway dialects: the `neon-ai-gateway` skill

--- a/with-mcp/.agents/skills/neon-functions/references/sentry.md
+++ b/with-mcp/.agents/skills/neon-functions/references/sentry.md
@@ -1,0 +1,131 @@
+# Integrations and observability
+
+A Neon Function is a **long-lived Node.js 24 process running a web-standard request/response handler** — not an edge worker or a short-lived lambda. That means any integration SDK that works in an ordinary Node process works here unchanged: you initialize it once at module load, before your handler starts serving requests, and it stays instrumented for the life of the isolate.
+
+This reference walks through wiring up Sentry for error and performance monitoring; the same shape (init module imported first, gated on an env var, secret passed at deploy time) applies to other Node SDKs (OpenTelemetry, logging, analytics).
+
+## Sentry (error & performance monitoring)
+
+Because the runtime is a normal Node process, use the Node SDK `@sentry/node` — not an edge/serverless wrapper. It bundles cleanly through `neonctl deploy`'s esbuild with no extra build config.
+
+There are three layers worth instrumenting, and errors from all of them flow into a single Sentry project:
+
+1. The HTTP framework (unhandled route errors).
+2. The Node function runtime (uncaught exceptions / unhandled rejections, captured by the SDK).
+3. The application's own caught failures — e.g. an agent that retries and falls back instead of throwing.
+
+### 1. Initialize before anything else
+
+Put `Sentry.init` in its own module and import it as the very first import of your entry file, so the process is instrumented before any other code (your handler, the DB pool, the agent) loads.
+
+```typescript
+// src/instrument.ts
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  enabled: Boolean(process.env.SENTRY_DSN),
+  tracesSampleRate: 1.0,
+  // NEON_BRANCH (the branch name) is injected on EVERY branch, including the default — so it
+  // can't be used as a truthy "is this a branch?" flag. Treat the project's default branch as
+  // "production" (its name passed in via neon.ts env) and tag every other branch by its name.
+  environment:
+    process.env.NEON_BRANCH && process.env.NEON_BRANCH !== process.env.PRODUCTION_BRANCH
+      ? process.env.NEON_BRANCH
+      : "production",
+});
+
+export { Sentry };
+```
+
+```typescript
+// src/index.ts
+import "./instrument"; // MUST be the first import, before the framework/agent
+import { Sentry } from "./instrument";
+import { Hono } from "hono";
+// ... rest of the function
+```
+
+- **Gate `enabled` on the DSN.** Local dev (`neonctl dev`) and any branch where you haven't configured the secret then become a no-op — no init, no noise — without changing code.
+- **Tag the environment off the injected branch name.** Each Neon branch runs its own copy of the function and the runtime injects `NEON_BRANCH` (the branch **name**, e.g. `main` or `preview/add-auth`) into every one of them — including the default branch. The same value is written into local dev by `neonctl env pull` / `neon-env run` / `neonctl dev`, so local and deployed runs agree. Because it's always present, don't use it as a boolean flag (that tags every branch the same). Instead compare it against your default branch name (pass it in as e.g. `PRODUCTION_BRANCH` via `neon.ts` `env`) so the default branch reads as `production` and feature/preview branches are tagged by name — keeping them separable in the Sentry dashboard.
+
+### 2. Provide the DSN as a deploy-time secret
+
+The DSN is your own secret, so set it per-deployment (see "Environment variables" in `SKILL.md`). Either pass it on deploy:
+
+```bash
+neonctl functions deploy <slug> --src src/index.ts \
+  --env "SENTRY_DSN=https://…@…ingest.us.sentry.io/…"
+```
+
+or declare it under the function's `env` in `neon.ts` (read from `process.env` to avoid hardcoding):
+
+```typescript
+functions: {
+  <slug>: {
+    name: "…",
+    source: "src/index.ts",
+    env: { SENTRY_DSN: process.env.SENTRY_DSN! },
+  },
+}
+```
+
+### 3. Catch unhandled route errors
+
+Wire a top-level error handler in your HTTP framework so any error thrown in a route is reported. With Hono, `onError` covers this. Watch out for one gotcha: framework middleware such as `cors()` usually does **not** decorate error responses, so re-add any headers you need on the 500 yourself.
+
+```typescript
+app.onError((err, c) => {
+  Sentry.captureException(err);
+  c.header("access-control-allow-origin", "*"); // cors() doesn't run on error responses
+  return c.json({ error: "internal_error" }, 500);
+});
+```
+
+### 4. Report agent (and other swallowed) failures explicitly
+
+Long-running agent workloads — the case Neon Functions are built for — typically **catch their own errors and fall back** (retry a different model, return a degraded result) rather than throwing. Those failures never reach the route error handler, so report them explicitly with the same `Sentry` instance, and tag them so you can filter and group in the dashboard.
+
+A representative agent that parses a page across several models reports three distinct cases:
+
+```typescript
+// Recoverable: one model attempt failed, the agent will try the next model.
+Sentry.captureException(err, {
+  level: "warning",
+  tags: { component: "agent", phase: "parse-attempt", model },
+  extra: { url, source },
+});
+
+// Terminal: every model failed.
+Sentry.captureException(err, {
+  level: "error",
+  tags: { component: "agent", phase: "parse-all-failed" },
+  extra: { url, source },
+});
+
+// Non-exception failure: the agent couldn't fetch the input page at all.
+Sentry.captureMessage("agent could not fetch page", {
+  level: "warning",
+  tags: { component: "agent", phase: "fetch" },
+  extra: { url, source },
+});
+```
+
+- Use `level` to separate recoverable (`warning`) from terminal (`error`) failures.
+- Use `tags` for the dimensions you'll filter/group by — `component`, `phase`, `model`.
+- Use `extra` for per-event context — the URL being processed, the content source.
+
+### Verifying the wiring
+
+- Temporarily add a route that throws (`app.get("/debug-sentry", () => { throw new Error("sentry test"); })`), hit it, confirm the 500 surfaces in Sentry, then remove the route.
+- Trigger a real downstream failure (e.g. point a fetch at `https://httpstat.us/500`) to confirm the explicit agent-level captures fire.
+
+## Other Node integrations
+
+The same pattern generalizes to any Node integration (OpenTelemetry, structured logging, product analytics):
+
+1. Initialize once at module scope in a dedicated init module, imported before your handler.
+2. Gate it on an env var so local dev and unconfigured branches are a no-op.
+3. Pass secrets via `--env KEY=VALUE` on deploy or the function's `env` in `neon.ts`.
+
+Standard Node SDKs bundle through `neonctl deploy`'s esbuild without changes.

--- a/with-mcp/.agents/skills/neon-functions/references/sse.md
+++ b/with-mcp/.agents/skills/neon-functions/references/sse.md
@@ -1,0 +1,147 @@
+# Server-sent events (SSE) on Neon Functions
+
+SSE is the one-way (server → client) streaming counterpart to WebSockets: the browser opens a long-lived `GET` with [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) and the server pushes text frames down it. On Neon Functions there's **no adapter or extra library to install** — unlike the [Hono WebSocket helper](hono-websockets.md), an SSE endpoint is just a normal `fetch` handler that returns a `Response` whose body is a `ReadableStream` with `Content-Type: text/event-stream`. The runtime holds the response open as long as bytes keep flowing (15-minute heartbeat, see [Timeouts](../SKILL.md#timeouts-and-runtime-limits)).
+
+Reach for SSE over WebSockets when you only need server → client updates (live counters, notifications, progress, token streams) — it's simpler to run (plain HTTP, no `upgrade`), and `EventSource` **reconnects on its own**, so there's no client backoff to write.
+
+## Minimal SSE endpoint (no framework)
+
+A function's default export is `{ fetch }`; SSE needs nothing more. Return a `ReadableStream` and write `data:` frames into it:
+
+```typescript
+// src/index.ts
+const encoder = new TextEncoder();
+
+export default {
+  fetch(request: Request): Response {
+    const url = new URL(request.url);
+    if (url.pathname !== "/events") return new Response("ok");
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // An SSE frame is `data: <payload>\n\n`. A line starting with `:` is a
+        // comment — used here as a heartbeat to keep the stream from going idle.
+        controller.enqueue(encoder.encode("data: hello\n\n"));
+        const timer = setInterval(
+          () => controller.enqueue(encoder.encode(": ping\n\n")),
+          25_000,
+        );
+        // cancel() fires when the client disconnects.
+        return () => clearInterval(timer);
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  },
+};
+```
+
+> `cancel()` is returned from `start()` here for brevity; you can also declare it as a separate `cancel()` method on the stream's underlying source. Either way, use it to drop the client from any broadcast set and clear timers.
+
+## With Hono
+
+Hono routes the HTTP side; the SSE response is the same `ReadableStream`. Returning a raw `Response` keeps full control over the stream (and sidesteps concurrent-write edge cases in stream helpers):
+
+```typescript
+// src/index.ts
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+const app = new Hono();
+app.use("*", cors({ origin: process.env.WEB_ORIGIN ?? "*" })); // EventSource is cross-origin from a SPA
+
+app.get("/events", (c) => {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("data: connected\n\n"));
+      // ...register `controller` in a broadcast set; see fan-out below.
+    },
+  });
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache, no-transform" },
+  });
+});
+
+export default app;
+```
+
+## Push to every client, across isolates
+
+The fan-out rule is identical to WebSockets ([Fan-out across isolates](../SKILL.md#fan-out-across-isolates-do-not-skip-this)): each isolate keeps its **own** set of open streams, so broadcasting in-process only reaches the clients on that isolate. Hold a `Set` of stream controllers, and fan out across isolates with Postgres `LISTEN`/`NOTIFY`. Keep the source-of-truth state in Postgres — module state doesn't survive eviction.
+
+```typescript
+import { Pool, Client } from "pg";
+
+const encoder = new TextEncoder();
+const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+const CHANNEL = "events";
+
+// One dedicated DIRECT connection per isolate to receive events (LISTEN needs a
+// real session — use DATABASE_URL_UNPOOLED, not the pooled URL).
+const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
+listener.on("notification", (msg) => {
+  if (!msg.payload) return;
+  const frame = encoder.encode(`data: ${msg.payload}\n\n`);
+  for (const controller of clients) {
+    try {
+      controller.enqueue(frame); // enqueue is synchronous — no concurrent-await hazard
+    } catch {
+      clients.delete(controller); // controller already closed
+    }
+  }
+});
+
+// Anywhere you mutate state, NOTIFY so every isolate pushes to its own streams.
+function publish(payload: unknown) {
+  return pool.query("SELECT pg_notify($1, $2)", [CHANNEL, JSON.stringify(payload)]);
+}
+
+process.on("SIGINT", () => {
+  Promise.allSettled([pool.end(), listener.end()]).then(() => process.exit(0));
+});
+```
+
+Register/unregister each connection in `clients` from the stream's `start`/`cancel`, and add a module-scope heartbeat (`setInterval`, every ~25–30s) that enqueues `: ping\n\n` to every controller so idle streams stay alive (see [Caveats](#caveats)).
+
+## Wire format (just text)
+
+Each event is newline-delimited fields ending in a blank line:
+
+```
+data: a one-line payload\n\n
+event: count\ndata: 42\n\n          # named event → addEventListener("count", …)
+id: 7\ndata: resumable\n\n            # sets EventSource.lastEventId for resume
+: this is a comment / heartbeat\n\n   # ignored by the client; keeps the stream warm
+retry: 5000\n\n                       # tells the client how long to wait before reconnecting
+```
+
+Send `data:` with no `event:` field to deliver the default `message` event, which the client reads with `EventSource.onmessage` (no `addEventListener` needed).
+
+## Client
+
+```typescript
+const source = new EventSource(`${FUNCTION_URL}/events`); // GET only
+source.onmessage = (e) => console.log("update", e.data);  // default "message" events
+source.onerror = () => {/* EventSource auto-reconnects; nothing to do */};
+// source.close() to stop.
+```
+
+`EventSource` **reconnects automatically** with the server's `retry:` interval, replaying `Last-Event-ID` if you set `id:` — so unlike WebSockets you don't write a reconnect loop. Its constraints: it's **GET-only and can't set request headers**, so authenticate the same way as a [WebSocket](../SKILL.md#websocket-servers) — a `?token=` query param (verify with `jwtVerify` before streaming) or a cookie. (Use the modern `eventsource` polyfill if you need `Authorization` headers.)
+
+## Caveats
+
+- **Heartbeat or it dies.** Streams stay open only while bytes flow — Neon's window is 15 min ([Timeouts](../SKILL.md#timeouts-and-runtime-limits)), but intermediary proxies are usually far stricter (tens of seconds). Emit a `: ping\n\n` comment every ~25–30s so the stream never goes quiet.
+- **`no-transform`.** Set `Cache-Control: no-cache, no-transform` so proxies don't buffer or rewrite the stream.
+- **Enqueue is synchronous.** `controller.enqueue()` doesn't return a promise, so broadcasting from the `LISTEN` handler can't interleave awaits mid-write — wrap each in `try/catch` and drop dead controllers.
+- **CORS.** A SPA hits the function cross-origin, so set `Access-Control-Allow-Origin`. `EventSource` sends no credentials by default, so `*` is fine for public streams.
+- **One-way only.** SSE is server → client. For client → server, the browser makes normal `fetch`/`POST` calls (often to the same function); reach for [WebSockets](../SKILL.md#websocket-servers) only when you need bidirectional, low-latency frames.
+
+A full, verified build of this pattern — Hono `fetch` SSE endpoint, `LISTEN`/`NOTIFY` fan-out, heartbeat, a counter persisted in Postgres, and a client-only TanStack Router SPA consuming it with `EventSource` — is the `with-realtime-sse` example in [`neondatabase/examples`](https://github.com/neondatabase/examples/tree/main/with-realtime-sse).

--- a/with-mcp/.agents/skills/neon-postgres-branches/SKILL.md
+++ b/with-mcp/.agents/skills/neon-postgres-branches/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: neon-postgres-branches
+description: >-
+  Choose and create the right Neon branch type for testing and development.
+  Use when users ask about Neon branching, migration testing with real data,
+  isolated test environments, schema-only branch workflows for sensitive data,
+  or branch creation via Neon CLI or Neon MCP. Triggers include "Neon branch",
+  "test migrations safely", "branch production data", "schema-only branch",
+  "reset branch" and "sensitive data testing".
+---
+
+# Neon Postgres Branching
+
+The outcome of this skill should be a created Neon branch (or a clear, actionable next step if creation cannot proceed).
+Choose the correct branch type, then execute branch creation via MCP or CLI.
+
+- **Normal branch** for realistic migration and query testing with real data.
+- **Schema-only branch (Beta)** for sensitive data workflows where structure is needed without copying rows.
+
+## Branch Type Decision
+
+Use this decision rule first:
+
+1. If the user wants to test complex migrations, performance, or behavior against production-like data, choose a **normal branch**.
+2. If the user needs to avoid copying sensitive data, choose a **schema-only branch**.
+
+If the request is ambiguous, ask one clarifying question:
+"Do you need realistic data for testing, or only schema structure because the data is sensitive?"
+
+## Tool Selection: CLI or MCP
+
+Always support both Neon CLI and Neon MCP server. Prefer the tool the user already has installed and authenticated.
+
+MCP link: https://neon.com/docs/ai/neon-mcp-server.md
+CLI link: https://neon.com/docs/reference/cli-quickstart
+
+### Selection order
+
+1. Check MCP first in MCP-enabled environments:
+   - If Neon MCP tools are available and authenticated (for example, listing projects works), use MCP.
+2. If MCP is unavailable or not authenticated, check CLI:
+   - Run `neonctl --version` to confirm CLI is installed.
+   - Run `neonctl projects list` to confirm auth/context.
+3. If CLI is missing, direct installation via quickstart.
+4. If CLI is installed but not authenticated, guide the user through `neonctl auth` (or API key auth), then continue.
+5. If both MCP and CLI paths are unsuccessful, use the Neon REST API:
+   - https://neon.com/docs/guides/branching-neon-api.md
+
+### MCP branch flow
+
+1. Choose normal vs schema-only based on data sensitivity and migration-testing goals.
+2. Use branch tools (for example, `create_branch`) to create the branch.
+3. Validate with read tools (for example, `describe_branch`).
+4. For migration workflows, prefer branch-based migration flows before applying to main.
+
+## Create a Normal Branch (Preferred for Real-Data Migration Testing)
+
+Use this when the user needs realistic testing conditions.
+Real production-like data can expose edge cases your seed or data migration scripts miss, which helps catch migration issues before going live.
+
+Link: https://neon.com/docs/introduction/branching.md
+
+### Steps
+
+1. Use MCP if already available/authenticated; otherwise verify CLI with `neonctl --version`.
+2. Ensure project context is set (`neonctl set-context --project-id <your-project-id>`) or include `--project-id` on commands.
+3. Create branch:
+
+```bash
+neonctl branches create \
+  --name <branch-name> \
+  --parent <parent-branch-id-or-name> \
+  --expires-at 2026-12-15T18:02:16Z
+```
+
+4. Optionally fetch a connection string for the new branch:
+
+```bash
+neonctl connection-string <branch-name>
+```
+
+## Create a Schema-Only Branch (Beta, Sensitive Data)
+
+Use this when users must not copy production rows into the test branch.
+
+Link: https://neon.com/docs/guides/branching-schema-only.md
+
+### Steps
+
+1. Use MCP if already available/authenticated; otherwise verify CLI with `neonctl --version`.
+2. Create schema-only branch:
+
+```bash
+neonctl branches create \
+  --name <schema-only-branch-name> \
+  --parent <parent-branch-id-or-name> \
+  --schema-only \
+  --expires-at 2026-12-15T18:02:16Z
+```
+
+If multiple projects exist, include:
+
+```bash
+neonctl branches create \
+  --name <schema-only-branch-name> \
+  --parent <parent-branch-id-or-name> \
+  --schema-only \
+  --project-id <your-project-id> \
+  --expires-at 2026-12-15T18:02:16Z
+```
+
+### Beta Support Guidance (Mandatory)
+
+Schema-only branching is in Beta. If users report unexpected behavior, errors, or missing capabilities:
+
+1. Ask them to share feedback in the Neon Console:
+   - https://console.neon.tech/app/projects?modal=feedback
+2. Recommend opening a support conversation in the Neon Discord:
+   - https://discord.gg/92vNTzKDGp
+
+## Reset from parent
+
+Use this when a child branch has drifted and the user wants a clean refresh from the parent branch's latest schema and data.
+
+Link: https://neon.com/docs/guides/reset-from-parent.md
+
+### What it does
+
+- Fully replaces the child branch schema and data with the parent's latest state.
+- Does not merge; local changes on the child branch are lost.
+- Keeps the same connection details, but active connections are briefly interrupted during reset.
+
+### When to recommend it
+
+- Development or staging branch is too far behind production.
+- User wants to start a new feature from a clean parent-aligned state.
+- Team wants to refresh staging from production for consistent testing baselines.
+
+### Hard constraints and blockers
+
+- Only child branches can be reset (root branches and schema-only root branches cannot be reset from parent).
+- If the target branch has children, reset is blocked until those child branches are removed.
+- After a parent branch is restored from snapshot, reset-from-parent may be unavailable for up to 24 hours.
+- Reset-from-parent always uses the current parent state; use Instant restore for point-in-time recovery needs.
+
+### CLI usage
+
+```bash
+neonctl branches reset <id|name> --parent --preserve-under-name <backup-branch-name>
+```
+
+If project context is not already set, include project ID:
+
+```bash
+neonctl branches reset <id|name> --parent --preserve-under-name <backup-branch-name> --project-id <project-id>
+```
+
+`--preserve-under-name` keeps the pre-reset state as a backup branch for rollback, but adds one extra branch to clean up later.
+
+Optional context setup to avoid repeating `--project-id`:
+
+```bash
+neonctl set-context --project-id <project-id>
+```
+
+### Console and API usage
+
+- **Console:** Open the target child branch, then select **Reset from parent** from **Actions**.
+- **API:** Use the restore endpoint for the branch and set `source_branch_id` to the parent branch ID.
+
+## Notes and Caveats
+
+- Schema-only branches are for structure-only cloning and sensitive/compliant data controls.
+- Schema-only branches are independent root branches (no parent branch and no shared history), so reset-from-parent does not apply.
+- For migration testing that depends on real-world row shapes, volumes, and edge cases, prefer normal branches.
+- Root branch allowances and per-branch storage limits can cap how many schema-only branches users can create.
+- If a user is unsure, default recommendation is:
+  - **Normal branch** for migration validation.
+  - **Schema-only branch** for compliance and privacy constraints.
+
+## Useful Workflow Patterns
+
+If the user asks for process recommendations (not just a single command), suggest these:
+
+- **One branch per PR:** Create branch when PR opens, delete when merged/closed, keep migration tests isolated.
+- **One branch per test run:** Create branch at pipeline start, run migrations/tests, delete at end for deterministic CI.
+- **One branch per developer:** Isolated dev environments with production-like shape; avoid team collisions on shared test data.
+- **PII-aware branching:** If production has sensitive data, derive dev/PR branches from an anonymized branch or use schema-only branches.
+- **Ephemeral lifecycle hygiene:** Set branch expiration and automate cleanup so old branches do not accumulate avoidable storage/history cost.
+
+### Post-creation environment update prompt
+
+After branch creation, ask whether the user wants to update local environment credentials to point at the new branch.
+
+- Ask: "Do you want me to update your `.env` `DATABASE_URL` to this new branch connection string?"
+- If yes, write the new branch connection string to the requested env file/key.
+- If no, leave credentials unchanged and share the connection string for manual use.
+- Never overwrite an existing env key without explicit confirmation.
+
+## Neon Infrastructure as Code (`neon.ts`)
+
+Beyond creating branches imperatively (CLI / MCP / API above), you can **program what configuration new branches receive** declaratively in `neon.ts` — Neon's infrastructure-as-code file (see the `neon` skill for the full reference). The `branch` property is a function of the branch being evaluated that returns its settings, so every branch born from your project gets a consistent lifecycle and compute profile without per-branch flags.
+
+```bash
+npm i @neondatabase/config
+```
+
+```typescript
+// neon.ts
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  branch: (branch) => {
+    if (branch.exists) return {}; // never reconcile existing branches
+    if (branch.isDefault) return { protected: true };
+    if (branch.name.startsWith("preview/") || branch.name.startsWith("dev")) {
+      return {
+        parent: "main",
+        ttl: "7d", // ephemeral: auto-expire 7 days after creation (max 30d)
+        postgres: {
+          computeSettings: {
+            autoscalingLimitMinCu: 0.25, // scale to zero
+            autoscalingLimitMaxCu: 1, // keep throwaway branches cheap
+            suspendTimeout: "5m",
+          },
+        },
+      };
+    }
+    return {};
+  },
+});
+```
+
+The closure receives a read-only descriptor of the target branch — `name`, `exists`, `isDefault`, `parentId`, and more — and returns the tuning to apply: `parent`, `ttl` (auto-expiry), `protected`, and `postgres.computeSettings`. This is the declarative complement to the **Ephemeral lifecycle hygiene** and per-PR / per-test patterns above: instead of remembering `--expires-at` on every `neonctl branches create`, the TTL and compute profile live in version control and apply to every matching branch.
+
+Because `neonctl checkout` applies this policy when it **creates** a branch, a fresh `preview/*` or `dev-*` branch comes up already expiring and scaled-to-zero. Checking out an _existing_ branch doesn't reconcile it — run `neonctl deploy` (alias for `neonctl config apply`) to apply changes to a branch that already exists.
+
+## Branching in CI/CD
+
+Common CI/CD use cases for Neon branches:
+
+- **Per-PR preview deployments:** Branch on PR open, deploy the preview against it, delete on close. Each PR gets an isolated database branch. Injecting the branch's `DATABASE_URL` into the deployed app is hosting-provider-specific — see [preview-branches-with-cloudflare](https://github.com/neondatabase/preview-branches-with-cloudflare), [preview-branches-with-vercel](https://github.com/neondatabase/preview-branches-with-vercel), or [preview-branches-with-fly](https://github.com/neondatabase/preview-branches-with-fly) for tested patterns.
+- **Migration testing in CI:** Run risky schema changes against a branch with production-like data before merge.
+- **Schema diff visibility:** Use the [schema-diff GitHub Action](https://github.com/marketplace/actions/neon-schema-diff-github-action) to auto-comment a DB-layer diff on the PR.
+
+## Examples
+
+### Example 1: Migration testing with realistic data
+
+**User input:** "I need to test a risky migration against production-like data."
+
+**Agent output shape:**
+
+1. Recommend a normal branch and explain why.
+2. Share docs link: https://neon.com/docs/introduction/branching
+3. Check the available/authenticated tool path first (MCP, otherwise CLI with `neonctl --version`).
+4. Provide commands:
+   - `neonctl branches create --name migration-test --parent main --expires-at 2026-12-15T18:02:16Z`
+   - `neonctl connection-string migration-test`
+
+### Example 2: Sensitive data development workflow
+
+**User input:** "We cannot copy production data because of compliance."
+
+**Agent output shape:**
+
+1. Recommend schema-only branch and explain why.
+2. Share docs link: https://neon.com/docs/guides/branching-schema-only
+3. Check the available/authenticated tool path first (MCP, otherwise CLI with `neonctl --version`).
+4. Provide command:
+   - `neonctl branches create --name compliance-dev --parent main --schema-only --project-id <your-project-id> --expires-at 2026-12-15T18:02:16Z`
+5. Mention Beta support path:
+   - https://console.neon.tech/app/projects?modal=feedback
+   - https://discord.gg/92vNTzKDGp
+
+## Further reading
+
+- https://neon.com/docs/guides/branch-expiration.md
+- https://neon.com/docs/guides/neon-github-integration.md
+- https://neon.com/docs/ai/neon-mcp-server.md
+- https://neon.com/branching

--- a/with-mcp/.agents/skills/neon-postgres/SKILL.md
+++ b/with-mcp/.agents/skills/neon-postgres/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: neon-postgres
+description: >-
+  Guides and best practices for working with Neon Serverless Postgres.
+  Covers setup, connection methods, branching, autoscaling, scale-to-zero,
+  read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server,
+  REST API, TypeScript SDK, and Python SDK.
+  Use when users ask about "Neon setup", "connect to Neon", "Neon project",
+  "DATABASE_URL", "serverless Postgres", "Neon CLI", "neonctl", "Neon MCP",
+  "Neon Auth", "@neondatabase/serverless", "@neondatabase/neon-js",
+  "scale to zero", "Neon autoscaling", "Neon read replica", or
+  "Neon connection pooling".
+---
+
+# Neon Serverless Postgres
+
+Guide the user through any Neon-related task: setup, connections, branching, and advanced features. Deliver a working Neon connection, a completed feature configuration, or a specific answer from the official Neon docs.
+
+Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.
+
+## Neon Documentation
+
+The Neon documentation is the source of truth for all Neon-related information. Always verify claims against the official docs before responding. Neon features and APIs evolve, so prefer fetching current docs over relying on training data.
+
+### Fetching Docs as Markdown
+
+Any Neon doc page can be fetched as markdown in two ways:
+
+1. **Append `.md` to the URL** (simplest): https://neon.com/docs/introduction/branching.md
+2. **Request `text/markdown`** on the standard URL: `curl -H "Accept: text/markdown" https://neon.com/docs/introduction/branching`
+
+Both return the same markdown content. Use whichever method your tools support.
+
+### Finding the Right Page
+
+The docs index lists every available page with its URL and a short description:
+
+```
+https://neon.com/docs/llms.txt
+```
+
+Common doc URLs are organized in the topic links below. If you need a page not listed here, search the docs index: https://neon.com/docs/llms.txt. Don't guess URLs.
+
+## What Is Neon
+
+Use this for architecture explanations and terminology (organizations, projects, branches, endpoints) before giving implementation advice.
+
+Link: https://neon.com/docs/introduction/architecture-overview.md
+
+## Getting Started
+
+Use this section when guiding a user through first-time Neon setup.
+
+### Check Status Quo
+
+Before starting setup, inspect the user's codebase and environment:
+
+- Existing database connection code
+- Existing Neon MCP server or Neon CLI configuration
+- Existence of a `.env` file and `DATABASE_URL` environment variable
+- Existing ORM (Prisma, Drizzle, TypeORM) configuration
+
+### Self-Driving Setup With Neon's CLI or MCP Server
+
+Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run init with the `--agent` flag. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
+
+```bash
+npx -y neonctl@latest init --agent <agent-name>
+```
+
+Supported `--agent` values: `cursor`, `copilot`, `claude`, `claude-desktop`, `codex`, `opencode`, `cline`, `gemini-cli`, `goose`, `zed`.
+
+This installs the Neon extension (for Cursor/VS Code) or MCP server (for other agents), creates an API key, and adds the `neon-postgres` agent skill to the project.
+
+If `init` is not suitable, the individual steps can be run non-interactively:
+
+- **Extension:** `cursor --install-extension databricks.neon-local-connect`
+- **MCP server:** `npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a <agent-name>`
+- **Agent skill:** `npx skills add neondatabase/agent-skills --skill neon-postgres --agent <agent-name> -y`
+
+For full CLI installation options, see https://neon.com/docs/reference/cli-install.md
+
+### Setup Flow
+
+**1. Select Organization and Project**
+
+Use MCP server or CLI to list organizations and projects. Let the user select an existing project or create a new one.
+
+**2. Get Connection String**
+
+Use MCP server or CLI to get the connection string. Store it in `.env` as `DATABASE_URL`. Read the file first before modifying to avoid overwriting existing values.
+
+**3. Pick Connection Method & Driver**
+
+Refer to the connection methods guide to pick the correct driver based on deployment platform: https://neon.com/docs/connect/choose-connection.md
+
+**4. User Authentication with Neon Auth (if needed)**
+
+Skip for CLI tools, scripts, or apps without user accounts. If the app needs auth: use MCP server `provision_neon_auth` tool, then see the auth overview (https://neon.com/docs/auth/overview.md) for setup. For auth + database queries, see the JavaScript SDK reference (https://neon.com/docs/reference/javascript-sdk.md).
+
+**5. ORM Setup (optional)**
+
+Check for existing ORM (Prisma, Drizzle, TypeORM). If none, ask if they want one. For Drizzle integration, see https://neon.com/docs/guides/drizzle.md.
+
+**6. Schema Setup**
+
+- Check for existing migration files or ORM schemas
+- If none: offer to create an example schema or design one together
+
+### Resume Support
+
+If resuming setup, check what's already configured (MCP connection, `.env` with `DATABASE_URL`, dependencies, schema) and continue from the next incomplete step.
+
+### Security Reminders
+
+Remind users to use environment variables for credentials, never commit connection strings, and use least-privilege database roles.
+
+## Connection Methods & Drivers
+
+Use this when you need to pick the correct transport and driver based on runtime constraints (TCP, HTTP, WebSocket, edge, serverless, long-running).
+
+Link: https://neon.com/docs/connect/choose-connection.md
+
+### Recommended: Drizzle + the right driver for your runtime
+
+Always pair Neon with an ORM such as **Drizzle** for easy schema management and migrations. Pick the driver based on how the runtime treats your code:
+
+- **Long-running or shared-runtime environments → node-postgres (`pg`).** Neon Functions, and any host where the function runtime is shared across requests / runs on fluid compute (e.g. **Vercel** with Fluid compute), keep a module-scope process alive across many requests. Open a `pg` pool **once at module scope** and reuse it across requests.
+- **Fully isolated serverless (Lambda-style) → Neon's serverless driver (`@neondatabase/serverless`).** Hosts like **Netlify** spin up a fresh, isolated instance per request, so a persistent TCP pool can't be reused; the serverless driver queries over HTTP and is built for this.
+
+**Neon Functions / Vercel / fluid compute — Drizzle + node-postgres:**
+
+```typescript
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import * as schema from "./schema";
+
+// Created once at module scope; reused by every request the instance handles.
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+const db = drizzle({ client: pool, schema });
+```
+
+On **Vercel** (Fluid compute) also attach the pool with `attachDatabasePool` from `@vercel/functions`, so the function runtime drains idle connections before an instance suspends:
+
+```typescript
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { attachDatabasePool } from "@vercel/functions";
+import * as schema from "./schema";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+attachDatabasePool(pool); // let the Vercel runtime manage the pooled connections
+const db = drizzle({ client: pool, schema });
+```
+
+**Netlify and other fully-isolated serverless — Drizzle + Neon serverless driver:**
+
+```typescript
+import { drizzle } from "drizzle-orm/neon-http";
+import { neon } from "@neondatabase/serverless";
+
+const sql = neon(process.env.DATABASE_URL!);
+const db = drizzle({ client: sql });
+```
+
+### Serverless Driver
+
+Use this for `@neondatabase/serverless` patterns, including HTTP queries, WebSocket transactions, and runtime-specific optimizations.
+
+Link: https://neon.com/docs/serverless/serverless-driver.md
+
+### Neon JS SDK
+
+Use this for combined Neon Auth + Data API workflows with PostgREST-style querying and typed client setup.
+
+Link: https://neon.com/docs/reference/javascript-sdk.md
+
+## Developer Tools
+
+Use this for local development enablement with `npx -y neonctl@latest init --agent <agent-name>`, VSCode extension setup, and Neon MCP server configuration.
+
+| Tool             | URL                                             |
+| ---------------- | ----------------------------------------------- |
+| CLI Init Command | https://neon.com/docs/reference/cli-init.md     |
+| VSCode Extension | https://neon.com/docs/local/vscode-extension.md |
+| MCP Server       | https://neon.com/docs/ai/neon-mcp-server.md     |
+| Neon CLI         | https://neon.com/docs/reference/neon-cli.md     |
+
+### Neon CLI
+
+Use this for terminal-first workflows, scripts, and CI/CD automation with `neonctl`.
+
+Link: https://neon.com/docs/reference/neon-cli.md
+
+## Neon Admin API
+
+The Neon Admin API can be used to manage Neon resources programmatically. It is used behind the scenes by the Neon CLI and MCP server, but can also be used directly for more complex automation workflows or when embedding Neon in other applications.
+
+### Neon REST API
+
+Use this for direct HTTP automation, endpoint-level control, API key auth, rate-limit handling, and operation polling.
+
+Link: https://neon.com/docs/reference/api-reference.md
+
+### Neon TypeScript SDK
+
+Use this when implementing typed programmatic control of Neon resources in TypeScript via `@neondatabase/api-client`.
+
+Link: https://neon.com/docs/reference/typescript-sdk.md
+
+### Neon Python SDK
+
+Use this when implementing programmatic Neon management in Python with the `neon-api` package.
+
+Link: https://neon.com/docs/reference/python-sdk.md
+
+## Neon Auth
+
+Use this for managed user authentication setup, UI components, auth methods, and Neon Auth integration pitfalls in Next.js and React apps.
+
+Link: https://neon.com/docs/auth/overview.md
+
+Neon Auth is also embedded in the Neon JS SDK. Depending on your use case, you may want to use the Neon JS SDK instead of Neon Auth alone. See https://neon.com/docs/connect/choose-connection.md for more details.
+
+## Neon Infrastructure as Code (`neon.ts`)
+
+`neon.ts` is Neon's branch config and infrastructure-as-code file: declare which services your branches have, get type-safe env vars, and program per-branch compute — all in TypeScript (see the `neon` skill for the full reference). Postgres always exists on every branch, so you never declare the database itself; what you codify here is the Postgres-adjacent surface — Neon Auth, the Data API, and per-branch compute settings (autoscaling and scale-to-zero).
+
+Add it with `@neondatabase/config`:
+
+```bash
+npm i @neondatabase/config
+```
+
+```typescript
+// neon.ts
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  auth: true, // Neon Auth (adds NEON_AUTH_* env vars)
+  dataApi: true, // Data API (adds NEON_DATA_API_URL); requires auth: true (or an external IdP)
+  // Postgres exists on every branch; tune its compute per branch:
+  branch: (branch) => {
+    if (branch.exists) return {}; // leave existing branches untouched
+    if (branch.isDefault) return { protected: true }; // prod keeps default compute
+    return {
+      ttl: "7d", // non-prod branches auto-expire (max 30d)
+      postgres: {
+        computeSettings: {
+          autoscalingLimitMinCu: 0.25, // scale to zero
+          autoscalingLimitMaxCu: 1, // keep dev/preview cheap
+          suspendTimeout: "5m",
+        },
+      },
+    };
+  },
+});
+```
+
+Reconcile the declaration from the CLI — the Neon equivalent of `terraform plan` / `apply`:
+
+```bash
+neonctl config status   # print the branch's live config
+neonctl config plan     # dry-run diff of what apply would change
+neonctl config apply    # provision the declared services / settings
+neonctl deploy          # alias for `neonctl config apply`
+```
+
+Because `neonctl checkout` applies the policy as it **creates** a branch, a fresh branch comes up with these compute settings (and Auth / Data API) already in place. Checking out an _existing_ branch never reconciles it — run `neonctl deploy` to apply changes.
+
+Since `neon.ts` is TypeScript, invalid combinations fail to compile with an actionable message: the Data API verifies requests with Neon Auth by default, so `dataApi: true` without `auth: true` is a type error (the fix — `auth: true`, or `authProvider: 'external'` with a `jwksUrl` — is in the message). See the `neon` skill's type-safe config note.
+
+Read the resulting env back, typed and validated against the policy, with `parseEnv` from `@neondatabase/env`:
+
+```typescript
+import { parseEnv } from "@neondatabase/env/v1";
+import config from "./neon";
+
+const env = parseEnv(config);
+env.postgres.databaseUrl; // typed; enabling auth / dataApi above surfaces env.auth / env.dataApi
+```
+
+## Branching
+
+Use this when the user is planning isolated environments, schema migration testing, preview deployments, or branch lifecycle automation.
+
+Key points:
+
+- Branches are instant, copy-on-write clones (no full data copy).
+- Each branch has its own compute endpoint.
+- Use the neonctl CLI or MCP server to create, inspect, and compare branches.
+
+Link: https://neon.com/docs/introduction/branching.md
+
+For detailed branch creation workflows (normal vs schema-only branches, reset-from-parent, CLI/MCP selection), use the `neon-postgres-branches` skill if available
+
+Or fetch the full branching skill from the following URL:
+
+https://neon.com/docs/ai/skills/neon-postgres-branches/SKILL.md
+
+If this skill is not installed you can use the following command to install it:
+
+```bash
+npx skills add neondatabase/agent-skills --skill neon-postgres-branches
+```
+
+## Autoscaling
+
+Use this when the user needs compute to scale automatically with workload and wants guidance on CU sizing and runtime behavior.
+
+Link: https://neon.com/docs/introduction/autoscaling.md
+
+## Scale to Zero
+
+Use this when optimizing idle costs and discussing suspend/resume behavior, including cold-start trade-offs.
+
+Key points:
+
+- Idle computes suspend automatically (default 5 minutes, configurable) (unless disabled - launch & scale plan only)
+- First query after suspend typically has a cold-start penalty (around hundreds of ms)
+- Storage remains active while compute is suspended.
+
+Link: https://neon.com/docs/introduction/scale-to-zero.md
+
+## Instant Restore
+
+Use this when the user needs point-in-time recovery or wants to restore data state without traditional backup restore workflows.
+
+Key points:
+
+- History windows for instant restore depend on plan limits.
+- Users can create branches from historical points-in-time.
+- Time Travel queries can be used for historical inspection workflows.
+
+Link: https://neon.com/docs/introduction/branch-restore.md
+
+## Read Replicas
+
+Use this for read-heavy workloads where the user needs dedicated read-only compute without duplicating storage.
+
+Key points:
+
+- Replicas are read-only compute endpoints sharing the same storage.
+- Creation is fast and scaling is independent from primary compute.
+- Typical use cases: analytics, reporting, and read-heavy APIs.
+
+Link: https://neon.com/docs/introduction/read-replicas.md
+
+## Connection Pooling
+
+Use this when the user is in serverless or high-concurrency environments and needs safe, scalable Postgres connection management.
+
+Key points:
+
+- Neon pooling uses PgBouncer.
+- Add `-pooler` to endpoint hostnames to use pooled connections.
+- Pooling is especially important in serverless runtimes with bursty concurrency.
+
+Link: https://neon.com/docs/connect/connection-pooling.md
+
+## IP Allow Lists
+
+Use this when the user needs to restrict database access by trusted networks, IPs, or CIDR ranges.
+
+Link: https://neon.com/docs/introduction/ip-allow.md
+
+## Logical Replication
+
+Use this when integrating CDC pipelines, external Postgres sync, or replication-based data movement.
+
+Key points:
+
+- Neon supports native logical replication workflows.
+- Useful for replicating to/from external Postgres systems.
+
+Link: https://neon.com/docs/guides/logical-replication-guide.md

--- a/with-mcp/.agents/skills/neon/SKILL.md
+++ b/with-mcp/.agents/skills/neon/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: neon
+description: >-
+  Overview of the Neon platform for apps and agents, spanning Postgres, Auth,
+  Data API, and the new services: Object Storage, Compute Functions, and AI
+  Gateway. Use whenever "Neon" is mentioned for an overview of how to work with Neon and how to get started. Otherwise, the individual capabilities are the triggers: "object storage" or "S3-compatible
+  storage", "serverless functions", "background jobs", or
+  "run code near my database", "AI gateway", "LLM proxy",
+  "model routing", or "call an LLM" → AI Gateway; "database", "Postgres", or
+  "authentication" → Postgres and Auth.
+---
+
+# Neon
+
+Important: Neon is no longer just a Serverless Postgres provider. Neon is the backend for apps and agents with Serverless Postgres, Auth, Functions, Storage, and an AI Gateway: instant, branchable, serverless.
+
+Use this skill as the starting point for anything Neon: get an overview of its capabilities, find your way around the Neon agent skills and documentation, and follow best practices for getting started and for branch-first development workflows.
+
+## Platform Services
+
+Neon bundles several backend primitives for building apps and agents that all branch together with your project:
+
+- **Postgres** — Serverless Postgres that scales and branches with your app. _Generally available._
+- **Auth** — Managed authentication with users and sessions stored in Postgres. _Generally available._
+- **Object Storage** — S3-compatible object storage that branches with your projects. _Preview / early access._
+- **Compute Functions** — Long-running serverless functions running close to your database — for WebSocket servers, long agent HTTP streams, APIs, and server-sent event servers. _Preview / early access._
+- **AI Gateway** — One API for all frontier and open-source models, with routing, logging, and cost controls, powered by Databricks. _Preview / early access._
+
+### Preview Service Availability
+
+Object Storage, Compute Functions, and AI Gateway are preview (early access) features.
+
+Early access features are only available on net-new projects created in the `us-east-2` region; they cannot be enabled on existing projects for now. Before guiding a user through any of these services, confirm they are working with a new project in `us-east-2`. If not, they will need to create a new project in that region. Then confirm the user already has early access; otherwise, point them to the private beta sign-up: https://neon.com/blog/were-building-backends#access.
+
+## Architecture: how Neon fits
+
+Neon is **not** a place to host your full-stack app — it's backend primitives (Postgres, Auth, Object Storage, Functions, AI Gateway) that **compose with** the application platform you already use. Host the app on **Vercel** (or Netlify, or another frontend/app host); Neon is the backend it talks to.
+
+A typical setup:
+
+- **Full-stack app on Vercel** (or Netlify) — e.g. Next.js or TanStack Start. It owns your UI and auth (e.g. **Neon Auth**) and talks directly to your **Neon Postgres** database and **Neon Object Storage**.
+- **Reach for Neon Functions when you outgrow the host's limits** — a WebSocket or SSE server, or long-running agents that risk timing out on short, lambda-style serverless. Run that one piece on a Neon Function, next to your data.
+
+You can also move your **whole backend control plane** onto Neon Functions. This is especially useful when the frontend is **client-only** rather than full-stack — TanStack Router, React Router in client mode, and similar SPAs hosted on Vercel or Netlify. The client talks **directly to Neon Functions**, where you build REST APIs and request/response agents, host **MCP servers**, and run anything stateful or that should live close to Postgres and Object Storage. Secure these functions like any standalone REST API — verify a JWT or API key at the top of each handler (see the `neon-functions` skill).
+
+Because Functions are just your backend, they compose with a full-stack app too: if you already have a backend (Next.js route handlers, etc.), Neon Functions sit alongside it, and you can **move pieces between the two** — e.g. relocate a long-running agent or a stateful WebSocket server off your host onto a Function when it needs more runtime.
+
+## Neon Documentation
+
+The Neon documentation is the source of truth for all Neon-related information. Always verify claims against the official docs before responding. Neon features and APIs evolve, so prefer fetching current docs over relying on training data.
+
+### Fetching Docs as Markdown
+
+Any Neon doc page can be fetched as markdown in two ways:
+
+1. **Append `.md` to the URL** (simplest): https://neon.com/docs/introduction/branching.md
+2. **Request `text/markdown`** on the standard URL: `curl -H "Accept: text/markdown" https://neon.com/docs/introduction/branching`
+
+Both return the same markdown content. Use whichever method your tools support.
+
+### Finding the Right Page
+
+The docs index lists every available page with its URL and a short description:
+
+```
+https://neon.com/docs/llms.txt
+```
+
+Common doc URLs are organized in the topic links below. If you need a page not listed here, search the docs index: https://neon.com/docs/llms.txt. Don't guess URLs.
+
+## Choosing the Right Skill
+
+- Working with the database, connections, schema, queries, autoscaling, or the CLI/MCP/API → `neon-postgres`.
+- Choosing or creating the right branch type for dev, preview, test, or CI workflows → `neon-postgres-branches`.
+- Storing and serving files (uploads, images, blobs) that branch with the database → `neon-object-storage`.
+- Deploying long-running or streaming serverless functions — APIs, agents, SSE/WebSocket servers — next to the database → `neon-functions`.
+- Calling an LLM or routing across model providers with one credential → `neon-ai-gateway`.
+- Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo) → `claimable-postgres`.
+- Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase → `neon-postgres-egress-optimizer`.
+
+### Installing the Right Skill
+
+First check whether the target skill is already installed and accessible (for example, it appears in the available skills list or its `SKILL.md` is present). If it is, use it directly. If it is not installed, install it via the `skills` CLI with `npx`/`bunx`:
+
+```bash
+npx skills add neondatabase/agent-skills -s <skill-name>
+```
+
+Replace `<skill-name>` with the skill you need (for example, `neon-object-storage`, `neon-functions`, or `neon-ai-gateway`). Useful flags:
+
+- `-g` — install globally instead of into the current project.
+- `-y` — non-interactive mode (skip prompts).
+- `-a <agent-name>` — pick the target agent(s) for non-interactive mode.
+
+For example, to install the object storage skill globally for a specific agent without prompts:
+
+```bash
+npx skills add neondatabase/agent-skills -s neon-object-storage -g -y -a <agent-name>
+```
+
+## Getting Started with Neon
+
+Use this section when guiding a user through first-time Neon setup, or when adding a new Neon service (Auth, object storage, functions, and so on) to a project that is already onboarded (for example, one already using Neon Postgres).
+
+### Check Status Quo
+
+Before starting setup, inspect the user's codebase and environment:
+
+- Existing database connection code
+- Existing `.neon` or `neon.ts` files in the workspace
+- Existing Neon MCP server or Neon CLI configuration
+- Existence of a `.env` file and `DATABASE_URL` environment variable
+- Existing ORM (Prisma, Drizzle, TypeORM) configuration
+
+### Self-Driving Setup With Neon's CLI or MCP Server
+
+Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run `npx -y neonctl init`. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
+
+```bash
+npx -y neonctl@latest init
+```
+
+This installs the Neon CLI and MCP server globally, installs the VSCode extension (for Cursor/VS Code), and adds the `neon` and `neon-postgres` agent skills to the project.
+
+If `init` is not suitable, the individual steps can be run non-interactively, using the user's preferred package manager (npm, bun, pnpm):
+
+- **CLI:** `npm i -g neonctl`
+- **Extension:** `cursor --install-extension databricks.neon-local-connect`
+- **MCP server:** `npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a <agent-name>`
+- **Agent skill:** `npx skills add neondatabase/agent-skills --skill neon-postgres --skill neon --agent <agent-name> -y`
+
+Prefer the CLI over the MCP server unless the user instructs otherwise, since it provides more capabilities, including deploying Neon Functions. For full CLI installation options, see https://neon.com/docs/reference/cli-install.md
+
+### Setup Flow
+
+Once the CLI, MCP server, and agent skills are installed, ensure the local workspace is linked to a Neon project through the `neonctl init` flow. If it isn't, run `npx -y neonctl link` to let the user interactively link a project. This produces a `.neon` file pointing to the organization, project, and branch the user wants to work with.
+
+For each Neon service, consult that component's agent skill for service-specific setup instructions (Functions, Postgres, Object Storage, Gateway, and so on).
+
+### Resume Support
+
+If resuming setup, check what's already configured (MCP connection, `.env` with `DATABASE_URL`, dependencies, schema) and continue from the next incomplete step.
+
+### Security Reminders
+
+Remind users to use environment variables for credentials, never commit connection strings, and use least-privilege database roles.
+
+## Branch-First Dev Flow
+
+Default to a branch-first loop that mirrors `git`: one isolated Neon branch per feature, so nothing leaks between features and there are no shared connection strings to copy around. Two commands drive it — `link` once per project, then `checkout` per feature — and a third, `env pull`, runs automatically under the hood so the branch you pin is immediately usable:
+
+- `neonctl link` — Interactively links the workspace to a Neon org, project, and branch, writing the IDs to a git-ignored `.neon` file. Run once per project. Once linked, project- and branch-scoped commands no longer need `--project-id` or `--branch` (for example, `neonctl branch list`).
+- `neonctl checkout <branch-name>` — Creates the branch if it doesn't exist, or checks out the existing one, by updating only the branch pointer in `.neon`. Run without a name for an interactive picker. It does not touch code or local Postgres.
+- `neonctl env pull` — Fetches the current branch's Neon environment variables (`DATABASE_URL`, …) into your existing `.env`, or `.env.local` if you don't have one (override the target with `--file`). No branch ID needed; it reads `.neon`. **`link` and `checkout` run this for you by default**, so you rarely call it directly.
+
+Run `link` once when starting on a project, then `checkout` per feature:
+
+```bash
+neonctl link                     # once; also pulls the linked branch's env
+neonctl checkout dev-add-search  # per feature; also pulls the branch's env
+```
+
+Because `link` and `checkout` pull env by default, the branch's `DATABASE_URL` lands in your local `.env` automatically — build against it, then `checkout` the next branch and repeat. As the agent, drive this loop yourself: run `checkout` between tasks to get a fresh, isolated database per feature with no shared state to corrupt.
+
+### Updating `.neon` without interactive prompts
+
+Plain `neonctl link` / `neonctl checkout` prompt interactively, which an agent can't answer. Use one of these non-interactive paths instead:
+
+- **`neonctl link --agent`** — a JSON state machine for agents. Each call returns a single JSON object with a `status` (`needs_org` → `needs_project` → `needs_project_details` → `linked`, or `error`), the available `options`, and the exact `next_command_template` to run next. Drive it step by step until `status: "linked"`. (Errors also come back as JSON with exit code 1, so you can always parse the result.)
+- **`neonctl set-context --project-id <id> --org-id <id> --branch-id <id>`** — when you already know the IDs, write all three into `.neon` in one shot. This is a **destructive write**: it replaces the file's contents entirely with exactly these fields, so it's the most direct way to point `.neon` at a specific org / project / branch.
+
+Both avoid prompts entirely; reach for `set-context` when you have the IDs and `link --agent` when you need to discover them.
+
+### Opting out of local env vars
+
+If env vars are injected at runtime instead of written to disk — or you simply don't want secrets in the working tree — pass `--no-env-pull` to `link` / `checkout` and supply the env another way:
+
+- `neon-env run -- <your dev command>` (from `@neondatabase/env`) fetches the branch's vars from your `neon.ts` and injects them into the child process at runtime — no `.env` file needed. This is the runtime counterpart to the on-disk `env pull`.
+- `neon-env export` (from `@neondatabase/env`) prints the branch's env to stdout as dotenv lines or, with `--format json`, JSON — for piping into another env manager rather than running a command. For example, [varlock](https://varlock.dev) can bulk-load it from a `.env.schema` with `@setValuesBulk(exec("neon-env export --format json"), format=json)`.
+- `fetchEnv` from `@neondatabase/env` is the programmatic version of the same thing: resolve the branch's env in code at runtime instead of shelling out to `neon-env run`.
+- `neonctl dev` injects the same vars into your local dev server — it's part of Neon Functions local development (a private preview feature).
+
+When an agent should not write a local `.env`, instruct it (for example in your `AGENTS.md`) to run `neonctl checkout <branch> --no-env-pull` and rely on runtime injection.
+
+For reading env you _already_ have on disk (typed and validated against your `neon.ts`), use `parseEnv` — see [Neon Infrastructure as Code](#neon-infrastructure-as-code) below.
+
+## Neon Infrastructure as Code
+
+`neon.ts` is Neon's branch config and infrastructure-as-code file: declare which Neon services your project's branches should have, get type-safe env vars, and program branch settings — all in TypeScript. It's the config layer for Neon as a platform, and it composes with the branch-first loop above. Add it with `@neondatabase/config`:
+
+```bash
+npm i @neondatabase/config
+```
+
+```typescript
+// neon.ts
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+});
+```
+
+### Provision services with neonctl config
+
+Every project ships with serverless Postgres; `neon.ts` lets you also declare Neon Auth and the Data API today, with Functions, buckets, and the AI Gateway under a `preview` block — every service for the branch composes in one file:
+
+```typescript
+// neon.ts
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+  preview: {
+    functions: { /* ... */ }, // see the neon-functions skill
+    buckets: { /* ... */ },    // see the neon-object-storage skill
+    aiGateway: true,           // see the neon-ai-gateway skill
+  },
+});
+```
+
+Reconcile the declaration from the CLI — the Neon equivalent of `terraform status` / `plan` / `apply`:
+
+```bash
+neonctl config status   # print the branch's live config (read-only)
+neonctl config plan     # dry-run diff of what apply would change (read-only)
+neonctl config apply    # provision the declared services
+neonctl deploy          # alias for `neonctl config apply`
+```
+
+`config status` and `config plan` only read state. `apply` / `deploy` — like `link` and `checkout` — provision the declared services **and then pull the branch's env into your local `.env.local`** (e.g. `Pulled 5 Neon variables into .env.local: DATABASE_URL, …`), so your local env always matches what's deployed.
+
+### Type-safe env vars with parseEnv
+
+`@neondatabase/env`'s `parseEnv` takes your `neon.ts` config object and returns a parsed, typed env object, validated against the services you declared. The shape of `env` follows your config — enable `auth` and you get `env.auth`, enable `dataApi` and you get `env.dataApi` — and missing variables are flagged with clear errors (for you and your agents). Use it to read env you already have (typically pulled into `.env` by `checkout` / `env pull`); for fetching env at runtime without a file, reach for `fetchEnv` / `neon-env run` instead.
+
+```bash
+npm i @neondatabase/env
+```
+
+```typescript
+import { parseEnv } from "@neondatabase/env/v1";
+import config from "./neon";
+
+const env = parseEnv(config);
+
+console.log(env.postgres.databaseUrl);
+console.log(env.auth.baseUrl);
+```
+
+By default `parseEnv` requires _every_ variable your config implies. When a process only uses a subset — a common case in frameworks like Next.js, where you might read `DATABASE_URL` but never the unpooled URL — pass an array of env-var keys to require and return only those. The keys are typesafe: autocomplete only offers variables your config enables, and the returned shape is narrowed to exactly what you selected (so unselected variables are neither enforced nor present).
+
+```typescript
+import { parseEnv } from "@neondatabase/env/v1";
+import config from "./neon";
+
+// Only DATABASE_URL is required and returned; DATABASE_URL_UNPOOLED is not enforced.
+const { postgres } = parseEnv(config, ["DATABASE_URL"]);
+console.log(postgres.databaseUrl);
+
+// Selecting across services — only these keys are validated/returned.
+const env = parseEnv(config, ["DATABASE_URL", "NEON_AUTH_BASE_URL"]);
+console.log(env.postgres.databaseUrl, env.auth.baseUrl);
+```
+
+### How checkout composes with neon.ts
+
+When a `neon.ts` is present, `neonctl checkout` applies your policy as it **creates** a branch, so a fresh branch comes up with its declared settings and services already in place. Checking out an _existing_ branch never reconciles it — apply config changes to it explicitly with `neonctl config apply` (or `neonctl deploy`). The bundled `env pull` also checks `neon.ts` against the linked branch and fails fast if the branch is missing a declared service, pointing you at `neonctl deploy` to provision it, so your local env and the remote branch never drift apart silently.
+
+### Branch configuration
+
+Beyond services, `neon.ts` can program what configuration _new_ branches receive via the `branch` property — a function of the branch being evaluated that returns its settings:
+
+```typescript
+// neon.ts
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+  branch: (branch) => {
+    if (branch.exists) {
+      // leave existing branches untouched
+      return {};
+    }
+    if (branch.name.startsWith("dev")) {
+      return {
+        ttl: "7d", // clean up the branch after 7 days
+        postgres: {
+          computeSettings: {
+            autoscalingLimitMinCu: 0.25, // scale to zero
+            autoscalingLimitMaxCu: 1, // keep it cheap
+            suspendTimeout: "5m",
+          },
+        },
+      };
+    }
+    return {};
+  },
+});
+```
+
+The `branch` function receives the target branch (its `name`, whether it `exists` yet, whether it's the default, and more) and returns the tuning you want. Here new `dev-*` branches get a 7-day TTL so they clean themselves up, plus a cheap scale-to-zero compute profile, while existing branches and everything else fall through to the defaults. Because `neonctl checkout` applies this policy on create, a fresh `dev-*` branch comes up with these settings already in place.
+
+### Type-safe config: invalid setups don't compile
+
+Because `neon.ts` is TypeScript, the compiler catches invalid infrastructure before you ever deploy — and Neon encodes the actual rules (and their fixes) into the types, so the error tells you what to do rather than failing with a useless `Type 'true' is not assignable to type 'never'`. The canonical case: the Data API verifies requests with Neon Auth by default, so enabling it on its own is a type error _on_ `dataApi`:
+
+```typescript
+export default defineConfig({
+  dataApi: true, // type error: `dataApi` (default authProvider 'neon') requires Neon Auth
+});
+```
+
+The message names both fixes, so pick one:
+
+```typescript
+// 1. Enable Neon Auth (the default Data API auth provider):
+export default defineConfig({ auth: true, dataApi: true });
+
+// 2. Or verify a third-party IdP instead of Neon Auth:
+export default defineConfig({
+  dataApi: { authProvider: "external", jwksUrl: "https://your-idp/.well-known/jwks.json" },
+});
+```
+
+Treat a `neon.ts` type error as the config telling you which services must go together — read the message, it spells out the valid combinations.
+
+## Gotchas
+
+### Neon Auth: "invalid domain"
+
+Neon Auth only redirects back to domains on its trusted-domains list. Anytime the domain your app runs on changes — a new production custom domain, a new deploy/preview URL, moving from `localhost` to a hosted environment, and so on — you must register the new domain with Neon Auth. Otherwise sign-in and OAuth callbacks fail with an **`invalid domain`** error because the redirect target isn't trusted.
+
+The easiest way to fix this is the CLI. With the workspace linked to the project (see the branch-first flow above), add the new domain to the trusted list:
+
+```bash
+neonctl neon-auth domain add <domain>   # e.g. neonctl neon-auth domain add https://app.example.com
+neonctl neon-auth domain list           # verify what's currently trusted
+neonctl neon-auth domain delete <domain> # remove one you no longer use
+```
+
+If the workspace isn't linked, pass `--project-id <id>` (and `--branch <id|name>`) explicitly. For local development, `neonctl neon-auth domain allow-localhost` manages whether `localhost` is permitted. Register the domain before pointing users at the new URL, so they never hit the `invalid domain` error.

--- a/with-mcp/.claude/skills/neon
+++ b/with-mcp/.claude/skills/neon
@@ -1,0 +1,1 @@
+../../.agents/skills/neon

--- a/with-mcp/.claude/skills/neon-functions
+++ b/with-mcp/.claude/skills/neon-functions
@@ -1,0 +1,1 @@
+../../.agents/skills/neon-functions

--- a/with-mcp/.claude/skills/neon-postgres
+++ b/with-mcp/.claude/skills/neon-postgres
@@ -1,0 +1,1 @@
+../../.agents/skills/neon-postgres

--- a/with-mcp/.claude/skills/neon-postgres-branches
+++ b/with-mcp/.claude/skills/neon-postgres-branches
@@ -1,0 +1,1 @@
+../../.agents/skills/neon-postgres-branches

--- a/with-mcp/.env.example
+++ b/with-mcp/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://neondb_owner:...@ep-...us-east-2.aws.neon.tech/neondb?sslmode=require"
+DATABASE_URL_UNPOOLED="postgresql://neondb_owner:...@ep-...us-east-2.aws.neon.tech/neondb?sslmode=require"

--- a/with-mcp/.gitignore
+++ b/with-mcp/.gitignore
@@ -1,0 +1,31 @@
+# dev
+.vercel/
+.yarn/
+!.yarn/releases
+.vscode/*
+!.vscode/launch.json
+!.vscode/*.code-snippets
+.idea/workspace.xml
+.idea/usage.statistics.xml
+.idea/shelf
+
+# deps
+node_modules/
+
+# env
+.env*
+!.env.example
+
+# logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# misc
+.DS_Store
+.vercel
+.neon

--- a/with-mcp/AGENTS.md
+++ b/with-mcp/AGENTS.md
@@ -1,0 +1,13 @@
+## Neon
+
+By default, when using the Neon CLI, always use the project `[PROJECT NAME]` (id: `[PROJECT ID]`).
+
+## Mandatory Feature Workflow
+
+For any feature, bug fix, or investigation that may touch app code using the database:
+
+1. Before editing application code, create a git feature branch.
+2. Before querying, migrating, or running database-backed app code, create a Neon branch in project `[PROJECT NAME]` (`[PROJECT ID]`).
+3. Set the Neon branch to expire after 7 days unless the user explicitly asks for a longer-lived branch.
+4. Update local `.env` so `DATABASE_URL` points to the new Neon branch.
+5. Apply schema changes only to the Neon feature branch, never production.

--- a/with-mcp/README.md
+++ b/with-mcp/README.md
@@ -1,0 +1,155 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://neon.com/brand/neon-logo-dark-color.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://neon.com/brand/neon-logo-light-color.svg">
+  <img width="250px" alt="Neon Logo fallback" src="https://neon.com/brand/neon-logo-dark-color.svg">
+</picture>
+
+# Getting started with Neon and MCP
+
+A minimal [Model Context Protocol](https://modelcontextprotocol.io) server that gives an AI agent CRUD access to a contact-management database. Built with the [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk), [Hono](https://hono.dev) (via [`@hono/mcp`](https://github.com/honojs/middleware/tree/main/packages/mcp)), [Neon](https://neon.com) Postgres, and [Drizzle ORM](https://orm.drizzle.team) — deployed as a Neon Function.
+
+The server exposes four tools over the streamable HTTP transport:
+
+| Tool              | Description                                                          |
+| ----------------- | ------------------------------------------------------------------- |
+| `create_contact`  | Create a contact (`name` required; `email`/`phone`/`company`/`notes` optional). |
+| `update_contact`  | Update an existing contact by `id` (only the fields you pass change). |
+| `delete_contact`  | Delete a contact by `id`.                                           |
+| `search_contacts` | Case-insensitive search across name/email/company/notes; omit the query to list all. |
+
+## Project structure
+
+```
+with-mcp/
+├── neon.ts             # Neon Functions policy (defineConfig) — what gets deployed
+├── drizzle.config.ts   # Drizzle Kit config (schema location + DB credentials)
+├── tsconfig.json
+├── .env.example        # Required environment variables
+├── src/
+│   ├── index.ts        # Hono app: MCP server + tools + db client (the function entry)
+│   └── db/
+│       └── schema.ts   # Drizzle schema (contacts table)
+└── package.json
+```
+
+## Clone the repository
+
+```bash
+npx degit neondatabase/examples/with-mcp ./with-mcp
+cd with-mcp
+```
+
+## Install and authenticate the Neon CLI
+
+```bash
+npm i -g neonctl
+neon login
+```
+
+## Install dependencies
+
+```bash
+npm install
+```
+
+## Link your Neon project
+
+Link (or create) a Neon project by running the `link` command from the workspace root:
+
+```bash
+neon link
+```
+
+If you let your agent drive this, add `--agent` to skip interactive mode.
+
+> Neon Functions is a preview feature available only on new projects in `us-east-2` — create your project in that region.
+
+> On a brand-new project, `neon link` runs an implicit `env pull` that will warn it can't find the function declared in `neon.ts`. That's expected — provision it in the next step, then the variables can be pulled.
+
+## Provision the declared services
+
+`neon.ts` declares the `contacts` function, but `neon link` does **not** provision the services it declares — `env pull` fails fast until they exist on the branch. Apply the policy first:
+
+```bash
+neonctl config apply
+```
+
+This registers the declared function on your branch so the environment pull can resolve everything in `neon.ts`.
+
+## Configure your environment
+
+With the policy applied, pull your branch-scoped environment variables into `.env.local`:
+
+```bash
+neonctl env pull
+```
+
+Inspect your `.env.local` file and ensure the `DATABASE_URL` has been set:
+
+```
+DATABASE_URL="postgresql://neondb_owner:...@ep-...us-east-2.aws.neon.tech/neondb?sslmode=require"
+```
+
+You can also find your connection string in the [Neon Console](https://console.neon.tech).
+
+## Apply the schema
+
+Push the Drizzle schema to your Neon database:
+
+```bash
+npm run db:push
+```
+
+## Run locally
+
+```bash
+neonctl dev
+```
+
+This serves the function at `http://localhost:8787`, with the MCP endpoint at `http://localhost:8787/mcp`.
+
+## Test the MCP server
+
+Any MCP client speaking the streamable HTTP transport can connect to `/mcp`. The examples below use [`mcporter`](https://github.com/instructa/mcporter), a small MCP CLI (`npm i -g mcporter`). `--allow-http` is only needed for local plain-HTTP URLs.
+
+```bash
+# List the available tools and their schemas
+mcporter list http://localhost:8787/mcp --schema --allow-http
+
+# Create a contact
+mcporter call "http://localhost:8787/mcp.create_contact" --allow-http \
+  name="Ada Lovelace" email="ada@analytical.engine" company="Analytical Engines"
+
+# Search contacts (omit query to list everyone)
+mcporter call "http://localhost:8787/mcp.search_contacts" --allow-http query="engine"
+
+# Update a contact (note key:value for numeric args)
+mcporter call "http://localhost:8787/mcp.update_contact" --allow-http id:1 phone="+1-555-0100"
+
+# Delete a contact
+mcporter call "http://localhost:8787/mcp.delete_contact" --allow-http id:1
+```
+
+To add it to an MCP-aware client (Cursor, Claude Desktop, etc.), point the client at the `/mcp` URL as a streamable HTTP server.
+
+## Deploy to Neon Functions
+
+Deploy the MCP server as a Neon Function to your branch:
+
+```bash
+neonctl deploy
+```
+
+## Test your deployed function
+
+Grab the function's invocation URL and connect your MCP client to its `/mcp` path:
+
+```bash
+# List the function to find its invocation URL
+neonctl functions get contacts
+
+# Then point an MCP client at it (replace with your URL)
+mcporter list https://<your-branch>-contacts.compute.<region>.aws.neon.tech/mcp --schema
+```
+
+> A Neon Function has a **public HTTPS URL — it is reachable by anyone.** This example keeps things minimal and does not authenticate callers. Before exposing a real MCP server, verify a token/API key at the top of the handler (see the `neon-functions` skill in `.agents/skills`).

--- a/with-mcp/README.md
+++ b/with-mcp/README.md
@@ -64,8 +64,6 @@ If you let your agent drive this, add `--agent` to skip interactive mode.
 
 > Neon Functions is a preview feature available only on new projects in `us-east-2` — create your project in that region.
 
-> On a brand-new project, `neon link` runs an implicit `env pull` that will warn it can't find the function declared in `neon.ts`. That's expected — provision it in the next step, then the variables can be pulled.
-
 ## Provision the declared services
 
 `neon.ts` declares the `contacts` function, but `neon link` does **not** provision the services it declares — `env pull` fails fast until they exist on the branch. Apply the policy first:

--- a/with-mcp/README.md
+++ b/with-mcp/README.md
@@ -62,8 +62,6 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-> Neon Functions is a preview feature available only on new projects in `us-east-2` — create your project in that region.
-
 ## Provision the declared services
 
 `neon.ts` declares the `contacts` function, but `neon link` does **not** provision the services it declares — `env pull` fails fast until they exist on the branch. Apply the policy first:

--- a/with-mcp/README.md
+++ b/with-mcp/README.md
@@ -102,7 +102,13 @@ mcporter call "http://localhost:8787/mcp.update_contact" --allow-http id:1 phone
 mcporter call "http://localhost:8787/mcp.delete_contact" --allow-http id:1
 ```
 
-To add it to an MCP-aware client (Cursor, Claude Desktop, etc.), point the client at the `/mcp` URL as a streamable HTTP server.
+To add it to an MCP-aware client (Cursor, Claude Desktop, etc.), point the client at the `/mcp` URL as a streamable HTTP server. The quickest way is [`add-mcp`](https://www.npmjs.com/package/add-mcp), which writes the client config for you:
+
+```bash
+npx add-mcp http://localhost:8787/mcp -a cursor
+```
+
+Pass `-a <agent>` to target a specific client (e.g. `cursor`, `claude`); omit it to pick interactively. Swap in your deployed function URL once it's live.
 
 ## Deploy to Neon Functions
 

--- a/with-mcp/README.md
+++ b/with-mcp/README.md
@@ -62,31 +62,7 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-## Provision the declared services
-
-`neon.ts` declares the `contacts` function, but `neon link` does **not** provision the services it declares — `env pull` fails fast until they exist on the branch. Apply the policy first:
-
-```bash
-neonctl config apply
-```
-
-This registers the declared function on your branch so the environment pull can resolve everything in `neon.ts`.
-
-## Configure your environment
-
-With the policy applied, pull your branch-scoped environment variables into `.env.local`:
-
-```bash
-neonctl env pull
-```
-
-Inspect your `.env.local` file and ensure the `DATABASE_URL` has been set:
-
-```
-DATABASE_URL="postgresql://neondb_owner:...@ep-...us-east-2.aws.neon.tech/neondb?sslmode=require"
-```
-
-You can also find your connection string in the [Neon Console](https://console.neon.tech).
+`neon link` pulls your branch-scoped environment variables — including `DATABASE_URL` — into `.env.local`. You can also find your connection string in the [Neon Console](https://console.neon.tech).
 
 ## Apply the schema
 

--- a/with-mcp/drizzle.config.ts
+++ b/with-mcp/drizzle.config.ts
@@ -1,0 +1,16 @@
+import { config as loadEnv } from 'dotenv';
+import { defineConfig } from 'drizzle-kit';
+import { parseEnv } from '@neondatabase/env/v1';
+import neonConfig from './neon';
+
+loadEnv({ path: '.env.local' });
+const env = parseEnv(neonConfig);
+
+export default defineConfig({
+  out: './drizzle',
+  schema: './src/db/schema.ts',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: env.postgres.databaseUrl,
+  },
+});

--- a/with-mcp/neon.ts
+++ b/with-mcp/neon.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+    preview: {
+        functions: {
+            "contacts": {
+                name: "contacts mcp server",
+                source: "src/index.ts"
+            }
+        }
+    }
+})

--- a/with-mcp/package.json
+++ b/with-mcp/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "with-mcp",
+  "scripts": {
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push"
+  },
+  "dependencies": {
+    "@hono/mcp": "^0.3.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@neondatabase/config": "^0.8.0",
+    "@neondatabase/env": "^0.6.0",
+    "@neondatabase/functions": "^0.1.2",
+    "dotenv": "^16.4.5",
+    "drizzle-orm": "^0.45.2",
+    "hono": "^4.11.4",
+    "pg": "^8.21.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.10",
+    "drizzle-kit": "^0.31.10",
+    "typescript": "^5.6.3"
+  }
+}

--- a/with-mcp/skills-lock.json
+++ b/with-mcp/skills-lock.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "skills": {
+    "neon": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/neon/SKILL.md",
+      "computedHash": "b2a846755ab5ee70ea02d2ed672750da24d877e72fc69e59087833d2178e97c6"
+    },
+    "neon-functions": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/neon-functions/SKILL.md",
+      "computedHash": "babaa68bb9b0f6ef57d577c56e450b0781170656056a6842e4aedd44470235b8"
+    },
+    "neon-postgres": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/neon-postgres/SKILL.md",
+      "computedHash": "04b1701aa7be7ead8936a5455c9e448b71a6fb008001d8795b5d3cdca8008863"
+    },
+    "neon-postgres-branches": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/neon-postgres-branches/SKILL.md",
+      "computedHash": "c0ff429a18e64daa491469ce09a1b8e4b9de445b458c2d726b1b11d611044b04"
+    }
+  }
+}

--- a/with-mcp/src/db/schema.ts
+++ b/with-mcp/src/db/schema.ts
@@ -1,0 +1,12 @@
+import { pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+
+export const contacts = pgTable('contacts', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email'),
+  phone: text('phone'),
+  company: text('company'),
+  notes: text('notes'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});

--- a/with-mcp/src/index.ts
+++ b/with-mcp/src/index.ts
@@ -1,0 +1,166 @@
+import { Hono } from 'hono';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { and, eq, ilike, or } from 'drizzle-orm';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPTransport } from '@hono/mcp';
+import { parseEnv } from '@neondatabase/env/v1';
+import config from '../neon';
+import { contacts } from './db/schema';
+
+const { postgres } = parseEnv(config, ['DATABASE_URL']);
+
+// One pool per isolate, reused across requests (see the neon-functions skill).
+const pool = new Pool({ connectionString: postgres.databaseUrl, max: 5 });
+const db = drizzle(pool);
+
+process.on('SIGINT', () => {
+  pool.end().then(() => process.exit(0));
+});
+
+// Optional free-text field — a fresh schema per field so each carries its own
+// description in the generated tool schema (a shared instance would collapse to a $ref).
+const optionalText = (description: string) =>
+  z.string().trim().min(1).optional().describe(description);
+
+function asTextResult(payload: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+const mcpServer = new McpServer({
+  name: 'neon-contacts',
+  version: '1.0.0',
+});
+
+mcpServer.registerTool(
+  'create_contact',
+  {
+    title: 'Create contact',
+    description: 'Create a new contact in the contact management database.',
+    inputSchema: {
+      name: z.string().trim().min(1).describe('Full name of the contact (required).'),
+      email: optionalText('Email address.'),
+      phone: optionalText('Phone number.'),
+      company: optionalText('Company or organization.'),
+      notes: optionalText('Free-form notes about the contact.'),
+    },
+  },
+  async ({ name, email, phone, company, notes }) => {
+    const [row] = await db
+      .insert(contacts)
+      .values({ name, email, phone, company, notes })
+      .returning();
+    return asTextResult({ created: row });
+  },
+);
+
+mcpServer.registerTool(
+  'update_contact',
+  {
+    title: 'Update contact',
+    description: 'Update fields on an existing contact. Only provided fields are changed.',
+    inputSchema: {
+      id: z.number().int().positive().describe('ID of the contact to update.'),
+      name: optionalText('New full name.'),
+      email: optionalText('New email address.'),
+      phone: optionalText('New phone number.'),
+      company: optionalText('New company or organization.'),
+      notes: optionalText('New free-form notes.'),
+    },
+  },
+  async ({ id, ...fields }) => {
+    const updates = Object.fromEntries(
+      Object.entries(fields).filter(([, value]) => value !== undefined),
+    );
+    if (Object.keys(updates).length === 0) {
+      return asTextResult({ error: 'Provide at least one field to update.' });
+    }
+    const [row] = await db
+      .update(contacts)
+      .set({ ...updates, updatedAt: new Date() })
+      .where(eq(contacts.id, id))
+      .returning();
+    if (!row) {
+      return asTextResult({ error: `No contact found with id ${id}.` });
+    }
+    return asTextResult({ updated: row });
+  },
+);
+
+mcpServer.registerTool(
+  'delete_contact',
+  {
+    title: 'Delete contact',
+    description: 'Delete a contact by ID.',
+    inputSchema: {
+      id: z.number().int().positive().describe('ID of the contact to delete.'),
+    },
+  },
+  async ({ id }) => {
+    const [row] = await db.delete(contacts).where(eq(contacts.id, id)).returning();
+    if (!row) {
+      return asTextResult({ error: `No contact found with id ${id}.` });
+    }
+    return asTextResult({ deleted: row });
+  },
+);
+
+mcpServer.registerTool(
+  'search_contacts',
+  {
+    title: 'Search contacts',
+    description:
+      'Search contacts by name, email, company, or notes. Omit the query to list all contacts.',
+    inputSchema: {
+      query: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe('Case-insensitive substring to match; omit to list everyone.'),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .max(100)
+        .default(20)
+        .describe('Maximum number of contacts to return (default 20, max 100).'),
+    },
+  },
+  async ({ query, limit }) => {
+    const where = query
+      ? or(
+          ilike(contacts.name, `%${query}%`),
+          ilike(contacts.email, `%${query}%`),
+          ilike(contacts.company, `%${query}%`),
+          ilike(contacts.notes, `%${query}%`),
+        )
+      : undefined;
+    const rows = await db
+      .select()
+      .from(contacts)
+      .where(and(where))
+      .orderBy(contacts.name)
+      .limit(limit);
+    return asTextResult({ count: rows.length, contacts: rows });
+  },
+);
+
+// Connect the MCP server to the streamable HTTP transport once per isolate.
+const transport = new StreamableHTTPTransport();
+
+const app = new Hono();
+
+app.get('/', (c) => c.text('Neon contacts MCP server — connect an MCP client to POST /mcp'));
+
+app.all('/mcp', async (c) => {
+  if (!mcpServer.isConnected()) {
+    await mcpServer.connect(transport);
+  }
+  return transport.handleRequest(c);
+});
+
+export default app;

--- a/with-mcp/tsconfig.json
+++ b/with-mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  }
+}

--- a/with-realtime-chat/README.md
+++ b/with-realtime-chat/README.md
@@ -70,15 +70,15 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-## Provision and deploy the function
+## Provision and deploy
 
-`neon.ts` declares Neon Auth and the `chat` function, but `neon link` does **not** provision them — Neon Auth's credentials don't exist until the policy is applied. `neonctl deploy` applies the policy (enabling Neon Auth and deploying the `chat` function) and then pulls the resulting branch-scoped variables into `.env.local`:
+Provision the services declared in `neon.ts`:
 
 ```bash
 neonctl deploy
 ```
 
-> `neonctl deploy` automatically runs an env pull after applying the policy, writing the provisioned variables into `.env.local` (or `.env` if that's what the project uses). You should see `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_AUTH_BASE_URL`, and `NEON_AUTH_JWKS_URL`. No separate `env pull` step is needed.
+> Note: `neonctl deploy` automatically runs an `env pull` that fetches the declared services' credentials and environment variables and writes them to a local `.env.local` file for development.
 
 ## Apply the schema
 

--- a/with-realtime-chat/README.md
+++ b/with-realtime-chat/README.md
@@ -70,23 +70,15 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-## Provision the declared services
+## Provision and deploy the function
 
-`neon.ts` declares Neon Auth and the `chat` function. Apply the policy so they exist on your branch:
-
-```bash
-neonctl config apply
-```
-
-## Configure your environment
-
-Pull your branch-scoped variables into `.env.local`:
+`neon.ts` declares Neon Auth and the `chat` function, but `neon link` does **not** provision them — Neon Auth's credentials don't exist until the policy is applied. `neonctl deploy` applies the policy (enabling Neon Auth and deploying the `chat` function) and then pulls the resulting branch-scoped variables into `.env.local`:
 
 ```bash
-neonctl env pull
+neonctl deploy
 ```
 
-You should see `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_AUTH_BASE_URL`, and `NEON_AUTH_JWKS_URL`.
+> `neonctl deploy` automatically runs an env pull after applying the policy, writing the provisioned variables into `.env.local` (or `.env` if that's what the project uses). You should see `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_AUTH_BASE_URL`, and `NEON_AUTH_JWKS_URL`. No separate `env pull` step is needed.
 
 ## Apply the schema
 
@@ -125,13 +117,9 @@ npm run dev --prefix web
 
 Open `http://localhost:3000`, sign up, and open a second browser to watch messages arrive in realtime.
 
-## Deploy the function to Neon
+## Get the deployed function URL
 
-```bash
-neonctl deploy
-```
-
-Grab the function's invocation URL — this is your `wss://` endpoint:
+You already deployed the `chat` function in the provisioning step. Grab its invocation URL — this is your `wss://` endpoint (redeploy after changes with `neonctl deploy`):
 
 ```bash
 neonctl functions get chat

--- a/with-realtime-chat/README.md
+++ b/with-realtime-chat/README.md
@@ -70,8 +70,6 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-> `neon link` runs an implicit `env pull` that warns it can't find the function declared in `neon.ts` yet. That's expected — provision it in the next step.
-
 ## Provision the declared services
 
 `neon.ts` declares Neon Auth and the `chat` function. Apply the policy so they exist on your branch:

--- a/with-realtime-sse/README.md
+++ b/with-realtime-sse/README.md
@@ -67,23 +67,7 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-## Provision the declared services
-
-`neon.ts` declares the `counter` function. Apply the policy so it exists on your branch:
-
-```bash
-neonctl config apply
-```
-
-## Configure your environment
-
-Pull your branch-scoped variables into `.env.local`:
-
-```bash
-neonctl env pull
-```
-
-You should see `DATABASE_URL` and `DATABASE_URL_UNPOOLED`.
+`neon link` pulls your branch-scoped variables — `DATABASE_URL` and `DATABASE_URL_UNPOOLED` — into `.env.local`.
 
 ## Apply the schema
 

--- a/with-realtime-sse/README.md
+++ b/with-realtime-sse/README.md
@@ -67,8 +67,6 @@ neon link
 
 If you let your agent drive this, add `--agent` to skip interactive mode.
 
-> `neon link` runs an implicit `env pull` that warns it can't find the function declared in `neon.ts` yet. That's expected — provision it in the next step.
-
 ## Provision the declared services
 
 `neon.ts` declares the `counter` function. Apply the policy so it exists on your branch:


### PR DESCRIPTION
## Summary

Adds a new `with-mcp` example: a minimal **Model Context Protocol** server that gives an AI agent CRUD access to a contact-management database, deployed as a Neon Function.

- **Stack:** Anthropic MCP TypeScript SDK (`@modelcontextprotocol/sdk`) + Hono via `@hono/mcp` (`StreamableHTTPTransport`), backed by Neon Postgres through Drizzle.
- **Tools:** `create_contact`, `update_contact` (partial), `delete_contact`, `search_contacts` (case-insensitive across name/email/company/notes, or list-all).
- Single `app.all('/mcp')` Hono route; module-scope `pg` pool per the `neon-functions` skill.
- README mirrors the other examples (clone → CLI → link → provision → env → schema → run → test → deploy), plus `AGENTS.md`, vendored `.agents`/`.claude` skills, and `skills-lock.json`.
- Registered in `bootstrap.yaml` as the `mcp` template.

## Test plan

- [x] `npm install`, `tsc --noEmit`, `npm run db:push` against a `us-east-2` test project.
- [x] `neonctl dev` + `mcporter` end to end: list tools, create x2, search by substring, update a field, delete (incl. missing-id error path), re-list.
- [ ] Reviewer: deploy with `neonctl deploy` and connect an MCP client to the deployed `/mcp` URL.

> Note: the example keeps things minimal and does **not** authenticate callers — the README/code flag adding a token check before exposing a real MCP server (its Function URL is public).