### PR TITLE
examples: adopt @neondatabase/ai-sdk-provider + drop /v1 import paths

### DIFF
--- a/with-ai-sdk/.env.example
+++ b/with-ai-sdk/.env.example
@@ -5,9 +5,9 @@
 DATABASE_URL="postgresql://neondb_owner:...@ep-...aws.neon.tech/neondb?sslmode=require"
 DATABASE_URL_UNPOOLED="postgresql://neondb_owner:...@ep-...aws.neon.tech/neondb?sslmode=require"
 
-# Neon AI Gateway (preview.aiGateway) — read automatically by the AI SDK's openai() provider
-OPENAI_API_KEY="nt_live_..."
-OPENAI_BASE_URL="https://<branch-id>-api.ai.<region>.aws.neon.tech/ai-gateway/openai/v1"
+# Neon AI Gateway (preview.aiGateway) — read automatically by @neondatabase/ai-sdk-provider
+NEON_AI_GATEWAY_TOKEN="nt_live_..."
+NEON_AI_GATEWAY_BASE_URL="https://<branch-id>-api.ai.<region>.aws.neon.tech"
 
 # Neon object storage (preview.buckets) — read automatically by the AWS S3 client
 AWS_ACCESS_KEY_ID="..."

--- a/with-ai-sdk/README.md
+++ b/with-ai-sdk/README.md
@@ -6,7 +6,7 @@
 
 # Getting started with Neon and the AI SDK
 
-An AI agent built with the [Vercel AI SDK](https://ai-sdk.dev), running on Neon Functions. It streams a chat completion through the [Neon AI Gateway](https://neon.com) and uses OpenAI's built-in `image_generation` tool: when the model calls it, a JPEG is generated, uploaded to a Neon-managed S3-compatible bucket, and indexed in [Neon](https://neon.com) Postgres via [Drizzle ORM](https://orm.drizzle.team).
+An AI agent built with the [Vercel AI SDK](https://ai-sdk.dev) (v6), running on Neon Functions. It streams a chat completion through the [Neon AI Gateway](https://neon.com) using the [`@neondatabase/ai-sdk-provider`](https://www.npmjs.com/package/@neondatabase/ai-sdk-provider) and the gateway's built-in `image_generation` tool: when the model calls it, a JPEG is generated, uploaded to a Neon-managed S3-compatible bucket, and indexed in [Neon](https://neon.com) Postgres via [Drizzle ORM](https://orm.drizzle.team).
 
 Everything the app needs — the database URL, the AI Gateway endpoint, and the object-storage credential — is declared in `neon.ts` and injected by `neonctl dev`, so there are no secrets to copy around.
 
@@ -36,7 +36,7 @@ with-ai-sdk/
 The handler:
 
 1. Streams the assistant's response as a UI-message stream (consumable by the AI SDK React/Vue/Svelte hooks).
-2. Uses an OpenAI/GPT-5 model on the Neon AI Gateway (`databricks-gpt-5-mini`) with the AI SDK's built-in `openai.tools.imageGeneration()` tool.
+2. Uses an OpenAI/GPT-5 model on the Neon AI Gateway (`gpt-5-mini`) via the `neon()` provider from `@neondatabase/ai-sdk-provider`, with the gateway's built-in `neon.tools.imageGeneration()` tool.
 3. When the model generates an image, the handler uploads the returned JPEG to your bucket and records the prompt + key + size in Postgres, logging a presigned view URL.
 
 > Notes on the gateway's image generation: it's the OpenAI Responses **`image_generation`** built-in tool (GPT-5 models only — there is no separate images endpoint), and the image is returned **inline as base64**. The gateway caps a response at ~640 KB, so this example requests a compressed JPEG (`outputFormat: 'jpeg'`, `quality: 'low'`, `outputCompression`) to stay under it; high-quality/large images can exceed the cap or hit the ~60s gateway timeout.

--- a/with-ai-sdk/drizzle.config.ts
+++ b/with-ai-sdk/drizzle.config.ts
@@ -1,6 +1,6 @@
 import { config as loadEnv } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import neonConfig from './neon';
 
 loadEnv({ path: '.env.local' });

--- a/with-ai-sdk/package.json
+++ b/with-ai-sdk/package.json
@@ -7,13 +7,13 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^2.0.0",
     "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/s3-request-presigner": "^3.700.0",
+    "@neondatabase/ai-sdk-provider": "^0.4.0",
     "@neondatabase/config": "^0.8.0",
     "@neondatabase/env": "^0.6.0",
     "@neondatabase/functions": "^0.1.2",
-    "ai": "^5.0.0",
+    "ai": "^6.0.0",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.45.2",
     "pg": "^8.21.0"
@@ -22,5 +22,8 @@
     "@types/pg": "^8.11.10",
     "drizzle-kit": "^0.31.10",
     "typescript": "^5.6.3"
+  },
+  "overrides": {
+    "@ai-sdk/provider-utils": "^4.0.28"
   }
 }

--- a/with-ai-sdk/src/index.ts
+++ b/with-ai-sdk/src/index.ts
@@ -1,11 +1,11 @@
-import { neon } from '@neondatabase/ai-sdk-provider/v1';
+import { neon } from '@neondatabase/ai-sdk-provider';
 import { streamText, type ModelMessage } from 'ai';
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { randomUUID } from 'node:crypto';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import config from '../neon';
 import { images } from './db/schema';
 

--- a/with-ai-sdk/src/index.ts
+++ b/with-ai-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import { openai } from '@ai-sdk/openai';
+import { neon } from '@neondatabase/ai-sdk-provider/v1';
 import { streamText, type ModelMessage } from 'ai';
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
@@ -20,7 +20,7 @@ const s3 = new S3Client({
 });
 
 const BUCKET = 'images';
-const MODEL = 'databricks-gpt-5-mini';
+const MODEL = 'gpt-5-mini';
 
 async function persistImage(prompt: string, jpegBase64: string) {
   const body = Buffer.from(jpegBase64, 'base64');
@@ -63,13 +63,13 @@ export default {
     const prompt = lastUserText(messages);
 
     const result = streamText({
-      model: openai(MODEL),
+      model: neon(MODEL),
       system:
         'You are an illustration agent. When the user asks for a picture, use the ' +
         'image_generation tool to create it, then briefly tell the user what you drew.',
       messages,
       tools: {
-        image_generation: openai.tools.imageGeneration({
+        image_generation: neon.tools.imageGeneration({
           outputFormat: 'jpeg',
           quality: 'low',
           outputCompression: 30,

--- a/with-hono/drizzle.config.ts
+++ b/with-hono/drizzle.config.ts
@@ -1,6 +1,6 @@
 import { config as loadEnv } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import neonConfig from './neon';
 
 loadEnv({ path: '.env.local' });

--- a/with-hono/src/index.ts
+++ b/with-hono/src/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import config from '../neon';
 import { todos } from './db/schema';
 

--- a/with-mastra/src/agent.ts
+++ b/with-mastra/src/agent.ts
@@ -1,7 +1,7 @@
 import { Agent } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
 import { PostgresStore } from '@mastra/pg';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import config from '../neon';
 
 const env = parseEnv(config);

--- a/with-mcp/drizzle.config.ts
+++ b/with-mcp/drizzle.config.ts
@@ -1,6 +1,6 @@
 import { config as loadEnv } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import neonConfig from './neon';
 
 loadEnv({ path: '.env.local' });

--- a/with-mcp/src/index.ts
+++ b/with-mcp/src/index.ts
@@ -5,7 +5,7 @@ import { and, eq, ilike, or } from 'drizzle-orm';
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPTransport } from '@hono/mcp';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import config from '../neon';
 import { contacts } from './db/schema';
 

--- a/with-realtime-chat/drizzle.config.ts
+++ b/with-realtime-chat/drizzle.config.ts
@@ -1,6 +1,6 @@
 import { config as loadEnv } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import neonConfig from './neon';
 
 loadEnv({ path: '.env.local' });

--- a/with-realtime-chat/src/index.ts
+++ b/with-realtime-chat/src/index.ts
@@ -5,7 +5,7 @@ import { WebSocketServer, type WebSocket } from 'ws';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool, Client } from 'pg';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import config from '../neon';
 import { messages } from './db/schema';
 

--- a/with-realtime-sse/drizzle.config.ts
+++ b/with-realtime-sse/drizzle.config.ts
@@ -1,6 +1,6 @@
 import { config as loadEnv } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import neonConfig from './neon';
 
 loadEnv({ path: '.env.local' });

--- a/with-realtime-sse/src/index.ts
+++ b/with-realtime-sse/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from 'hono/cors';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { eq, sql } from 'drizzle-orm';
 import { Pool, Client } from 'pg';
-import { parseEnv } from '@neondatabase/env/v1';
+import { parseEnv } from '@neondatabase/env';
 import config from '../neon';
 import { counters } from './db/schema';
 


### PR DESCRIPTION
## Summary

Two related changes to the examples:

1. **`with-ai-sdk`** now uses the released [`@neondatabase/ai-sdk-provider`](https://www.npmjs.com/package/@neondatabase/ai-sdk-provider) on **AI SDK v6** instead of the generic `@ai-sdk/openai` provider — `neon('gpt-5-mini')` + `neon.tools.imageGeneration()`, reading `NEON_AI_GATEWAY_BASE_URL` / `NEON_AI_GATEWAY_TOKEN` from the env. An `overrides` entry dedupes `@ai-sdk/provider-utils` so the provider's bundled `@ai-sdk/*` and the app's `ai@6` share one copy.
2. **All examples** now import the `@neondatabase/*` packages from the **package root** instead of the `/v1` subpath. The `/v1` subpath export is being removed from `@neondatabase/env`, `@neondatabase/functions`, and `@neondatabase/ai-sdk-provider` (see neondatabase/neon-pkgs#232); the root already exposes the same surface, so this is forward-compatible with both the current and upcoming package versions. `@neondatabase/config/v1` is unchanged (it keeps its versioned subpath).

## Test plan

- [x] `npx tsc --noEmit` passes for `with-ai-sdk`
- [x] `with-ai-sdk` verified end-to-end (`neon dev` + deployed function): streamed response, image generated, uploaded to object storage, and persisted to Postgres
- [x] Import paths swapped across `with-ai-sdk`, `with-mcp`, `with-mastra`, `with-hono`, `with-realtime-sse`, `with-realtime-chat`

> Dep version ranges are left as-is so installs keep resolving to currently-published versions; they can be bumped once neon-pkgs#232 is released.