### PR TITLE
chore(with-ai-sdk): drop @ai-sdk/provider-utils override after ai-sdk-provider 0.5.0

### DIFF
--- a/with-ai-sdk/package.json
+++ b/with-ai-sdk/package.json
@@ -9,10 +9,10 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/s3-request-presigner": "^3.700.0",
-    "@neondatabase/ai-sdk-provider": "^0.4.0",
+    "@neondatabase/ai-sdk-provider": "^0.5.0",
     "@neondatabase/config": "^0.8.0",
-    "@neondatabase/env": "^0.6.0",
-    "@neondatabase/functions": "^0.1.2",
+    "@neondatabase/env": "^0.8.0",
+    "@neondatabase/functions": "^0.3.0",
     "ai": "^6.0.0",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.45.2",
@@ -22,8 +22,5 @@
     "@types/pg": "^8.11.10",
     "drizzle-kit": "^0.31.10",
     "typescript": "^5.6.3"
-  },
-  "overrides": {
-    "@ai-sdk/provider-utils": "^4.0.28"
   }
 }


### PR DESCRIPTION
## Summary

Now that [`@neondatabase/ai-sdk-provider@0.5.0`](https://www.npmjs.com/package/@neondatabase/ai-sdk-provider) widened its `@ai-sdk/*` deps from exact pins to caret ranges (neondatabase/neon-pkgs#232), `@ai-sdk/provider-utils` dedupes with the app's `ai@6` on its own — the `overrides` workaround the example carried is no longer needed.

- Removed the `overrides` block (`@ai-sdk/provider-utils`).
- Bumped `@neondatabase/*` to the latest published versions: `ai-sdk-provider ^0.5.0`, `env ^0.8.0`, `functions ^0.3.0`.

## Test plan

- [x] Clean install (`rm -rf node_modules package-lock.json && npm install`) with no override
- [x] `npm ls @ai-sdk/provider-utils` → a **single** deduped copy (`4.0.29`)
- [x] `npx tsc --noEmit` passes