### PR TITLE
refactor(examples): share database client helpers

### DIFF
--- a/with-ai-sdk/src/db/client.ts
+++ b/with-ai-sdk/src/db/client.ts
@@ -1,0 +1,18 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { getDatabaseUrl } from "../env.js";
+
+const createDb = (databaseUrl: string) => {
+  const pool = new Pool({ connectionString: databaseUrl, max: 5 });
+
+  return drizzle(pool);
+};
+
+let db: ReturnType<typeof createDb> | undefined;
+
+export const getDb = () => {
+  db ??= createDb(getDatabaseUrl());
+
+  return db;
+};
+

--- a/with-ai-sdk/src/env.ts
+++ b/with-ai-sdk/src/env.ts
@@ -1,0 +1,10 @@
+import { parseEnv } from "@neon/env";
+import neonConfig from "../neon.js";
+
+let databaseUrl: string | undefined;
+
+export const getDatabaseUrl = () => {
+  databaseUrl ??= parseEnv(neonConfig, ["DATABASE_URL"]).postgres.databaseUrl;
+
+  return databaseUrl;
+};

--- a/with-ai-sdk/src/index.ts
+++ b/with-ai-sdk/src/index.ts
@@ -2,17 +2,11 @@ import { neon } from '@neon/ai-sdk-provider';
 import { streamText, type ModelMessage } from 'ai';
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { Pool } from 'pg';
 import { randomUUID } from 'node:crypto';
-import { parseEnv } from '@neon/env';
-import config from '../neon';
+import { getDb } from './db/client';
 import { images } from './db/schema';
 
-const env = parseEnv(config);
-
-const pool = new Pool({ connectionString: env.postgres.databaseUrl, max: 5 });
-const db = drizzle(pool);
+const db = getDb();
 
 const s3 = new S3Client({
   forcePathStyle:

--- a/with-hono/src/db/client.ts
+++ b/with-hono/src/db/client.ts
@@ -1,0 +1,18 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { getDatabaseUrl } from "../env.js";
+
+const createDb = (databaseUrl: string) => {
+  const pool = new Pool({ connectionString: databaseUrl, max: 5 });
+
+  return drizzle(pool);
+};
+
+let db: ReturnType<typeof createDb> | undefined;
+
+export const getDb = () => {
+  db ??= createDb(getDatabaseUrl());
+
+  return db;
+};
+

--- a/with-hono/src/env.ts
+++ b/with-hono/src/env.ts
@@ -1,0 +1,10 @@
+import { parseEnv } from "@neon/env";
+import neonConfig from "../neon.js";
+
+let databaseUrl: string | undefined;
+
+export const getDatabaseUrl = () => {
+  databaseUrl ??= parseEnv(neonConfig, ["DATABASE_URL"]).postgres.databaseUrl;
+
+  return databaseUrl;
+};

--- a/with-hono/src/index.ts
+++ b/with-hono/src/index.ts
@@ -1,14 +1,8 @@
 import { Hono } from 'hono';
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { Pool } from 'pg';
-import { parseEnv } from '@neon/env';
-import config from '../neon';
+import { getDb } from './db/client';
 import { todos } from './db/schema';
 
-const env = parseEnv(config);
-
-const pool = new Pool({ connectionString: env.postgres.databaseUrl, max: 5 });
-const db = drizzle(pool);
+const db = getDb();
 
 const app = new Hono();
 

--- a/with-mcp/src/db/client.ts
+++ b/with-mcp/src/db/client.ts
@@ -1,0 +1,18 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { getDatabaseUrl } from "../env.js";
+
+const createDb = (databaseUrl: string) => {
+  const pool = new Pool({ connectionString: databaseUrl, max: 5 });
+
+  return drizzle(pool);
+};
+
+let db: ReturnType<typeof createDb> | undefined;
+
+export const getDb = () => {
+  db ??= createDb(getDatabaseUrl());
+
+  return db;
+};
+

--- a/with-mcp/src/env.ts
+++ b/with-mcp/src/env.ts
@@ -1,0 +1,10 @@
+import { parseEnv } from "@neon/env";
+import neonConfig from "../neon.js";
+
+let databaseUrl: string | undefined;
+
+export const getDatabaseUrl = () => {
+  databaseUrl ??= parseEnv(neonConfig, ["DATABASE_URL"]).postgres.databaseUrl;
+
+  return databaseUrl;
+};

--- a/with-mcp/src/index.ts
+++ b/with-mcp/src/index.ts
@@ -1,19 +1,12 @@
 import { Hono } from 'hono';
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { Pool } from 'pg';
 import { and, eq, ilike, or } from 'drizzle-orm';
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPTransport } from '@hono/mcp';
-import { parseEnv } from '@neon/env';
-import config from '../neon';
+import { getDb } from './db/client';
 import { contacts } from './db/schema';
 
-const { postgres } = parseEnv(config, ['DATABASE_URL']);
-
-// One pool per isolate, reused across requests (see the neon-functions skill).
-const pool = new Pool({ connectionString: postgres.databaseUrl, max: 5 });
-const db = drizzle(pool);
+const db = getDb();
 
 // Optional free-text field — a fresh schema per field so each carries its own
 // description in the generated tool schema (a shared instance would collapse to a $ref).

--- a/with-realtime-chat/src/db/client.ts
+++ b/with-realtime-chat/src/db/client.ts
@@ -1,0 +1,18 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { getDatabaseUrl } from "../env.js";
+
+const createDb = (databaseUrl: string) => {
+  const pool = new Pool({ connectionString: databaseUrl, max: 5 });
+
+  return drizzle(pool);
+};
+
+let db: ReturnType<typeof createDb> | undefined;
+
+export const getDb = () => {
+  db ??= createDb(getDatabaseUrl());
+
+  return db;
+};
+

--- a/with-realtime-chat/src/env.ts
+++ b/with-realtime-chat/src/env.ts
@@ -1,0 +1,10 @@
+import { parseEnv } from "@neon/env";
+import neonConfig from "../neon.js";
+
+let databaseUrl: string | undefined;
+
+export const getDatabaseUrl = () => {
+  databaseUrl ??= parseEnv(neonConfig, ["DATABASE_URL"]).postgres.databaseUrl;
+
+  return databaseUrl;
+};

--- a/with-realtime-chat/src/index.ts
+++ b/with-realtime-chat/src/index.ts
@@ -2,17 +2,16 @@ import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import { Hono } from 'hono';
 import { WebSocketServer, type WebSocket } from 'ws';
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { Pool, Client } from 'pg';
+import { sql } from 'drizzle-orm';
+import { Client } from 'pg';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { parseEnv } from '@neon/env';
 import config from '../neon';
+import { getDb } from './db/client';
 import { messages } from './db/schema';
 
 const env = parseEnv(config);
-
-const pool = new Pool({ connectionString: env.postgres.databaseUrl, max: 5 });
-const db = drizzle(pool);
+const db = getDb();
 
 // Neon Auth signs tokens with the auth server's origin as the issuer.
 const jwks = createRemoteJWKSet(new URL(env.auth.jwksUrl));
@@ -84,7 +83,7 @@ export default {
           .returning();
         // NOTIFY fans the new row out to every isolate, which broadcasts to its
         // own connected clients (including the sender).
-        await pool.query('SELECT pg_notify($1, $2)', [CHANNEL, JSON.stringify(row)]);
+        await db.execute(sql`SELECT pg_notify(${CHANNEL}, ${JSON.stringify(row)})`);
       });
     });
   },

--- a/with-realtime-sse/src/db/client.ts
+++ b/with-realtime-sse/src/db/client.ts
@@ -1,0 +1,18 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { getDatabaseUrl } from "../env.js";
+
+const createDb = (databaseUrl: string) => {
+  const pool = new Pool({ connectionString: databaseUrl, max: 5 });
+
+  return drizzle(pool);
+};
+
+let db: ReturnType<typeof createDb> | undefined;
+
+export const getDb = () => {
+  db ??= createDb(getDatabaseUrl());
+
+  return db;
+};
+

--- a/with-realtime-sse/src/env.ts
+++ b/with-realtime-sse/src/env.ts
@@ -1,0 +1,10 @@
+import { parseEnv } from "@neon/env";
+import neonConfig from "../neon.js";
+
+let databaseUrl: string | undefined;
+
+export const getDatabaseUrl = () => {
+  databaseUrl ??= parseEnv(neonConfig, ["DATABASE_URL"]).postgres.databaseUrl;
+
+  return databaseUrl;
+};

--- a/with-realtime-sse/src/index.ts
+++ b/with-realtime-sse/src/index.ts
@@ -1,10 +1,10 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import { drizzle } from 'drizzle-orm/node-postgres';
 import { eq, sql } from 'drizzle-orm';
-import { Pool, Client } from 'pg';
+import { Client } from 'pg';
 import { parseEnv } from '@neon/env';
 import config from '../neon';
+import { getDb } from './db/client';
 import { counters } from './db/schema';
 
 const env = parseEnv(config);
@@ -13,8 +13,7 @@ const env = parseEnv(config);
 // SPA's origin. Defaults to "*" for the demo; set WEB_ORIGIN to lock it down.
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? '*';
 
-const pool = new Pool({ connectionString: env.postgres.databaseUrl, max: 5 });
-const db = drizzle(pool);
+const db = getDb();
 
 const COUNTER_ID = 1;
 const CHANNEL = 'counter_updates';
@@ -105,7 +104,7 @@ app.post('/increment', async (c) => {
   const value = await incrementCount();
   // NOTIFY fans the new value out to every isolate, each of which pushes it to
   // its own SSE clients (including whoever triggered the increment).
-  await pool.query('SELECT pg_notify($1, $2)', [CHANNEL, String(value)]);
+  await db.execute(sql`SELECT pg_notify(${CHANNEL}, ${String(value)})`);
   return c.json({ value });
 });
 


### PR DESCRIPTION
## Summary
- Share the Discord-style database client helper across Drizzle examples.

## Test plan
- ReadLints
- git diff --check