### PR TITLE
chore(discord-bot-http): remove unused package.json metadata

### DIFF
--- a/bots/discord-bot-http/package.json
+++ b/bots/discord-bot-http/package.json
@@ -1,8 +1,6 @@
 {
   "name": "neon-discord-bot",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "type": "module",
   "scripts": {
     "check": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
@@ -13,10 +11,6 @@
     "endpoint": "neon functions get discord",
     "register:commands": "rm -rf .tmp-register && tsc --outDir .tmp-register --noEmit false && node --env-file=.env .tmp-register/scripts/registerCommands.js"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
-  "type": "module",
   "dependencies": {
     "@discordjs/builders": "^1.14.1",
     "@neon/config": "^0.8.1",


### PR DESCRIPTION
## Summary
- Remove boilerplate `package.json` fields from the Discord bot HTTP example (`version`, `description`, `main`, `keywords`, `author`, `license`) to align with other Neon function examples.

## Test plan
- [x] `package.json` remains valid JSON with scripts and dependencies unchanged