### PR TITLE
feat: add files-sdk bootstrap template

### DIFF
--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -29,6 +29,19 @@ templates:
       repo: examples
       ref: main
       subdir: with-ai-sdk
+  - id: files-sdk
+    title: "Files SDK quickstart"
+    description: "A minimal script that uploads local files to a branch-scoped Neon object storage bucket using the Files SDK and its `neon` adapter, then prints presigned URLs."
+    tools:
+      - Files SDK
+      - TypeScript
+    services:
+      - Object Storage
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-files-sdk
   - id: mastra
     title: "Personal-assistant agent"
     description: "A Mastra agent that streams chat through the Neon AI Gateway and uses Mastra Memory on Neon Postgres to remember you across threads."


### PR DESCRIPTION
Registers the existing `with-files-sdk` example as a bootstrap template in `bootstrap.yaml`, so it shows in `neon bootstrap --list-templates` and can be scaffolded with `neon bootstrap --template files-sdk`.

The `with-files-sdk` directory already exists as a minimal Files SDK quickstart (uploads local files to a branch-scoped object storage bucket via the `neon` adapter, then prints presigned URLs), but it wasn't registered as a template. This adds the entry next to `ai-sdk`, the other Object Storage example.

- **id**: `files-sdk`
- **services**: Object Storage
- **source**: `with-files-sdk`

This pull request and its description were written by Isaac.