### PR TITLE
Say "Lakebase Postgres on Neon" where no Neon mention is nearby

### DIFF
--- a/auth/with-authjs-next/README.md
+++ b/auth/with-authjs-next/README.md
@@ -1,6 +1,6 @@
-# Next.js application with Lakebase Postgres and Auth.js authentication
+# Next.js application with Lakebase Postgres on Neon and Auth.js authentication
 
-This is a Next.js application that uses `Lakebase Postgres` as the database and `Auth.js` for user authentication. It allows users to log in using magic links and manage a simple todo list.
+This is a Next.js application that uses `Lakebase Postgres` on Neon as the database and `Auth.js` for user authentication. It allows users to log in using magic links and manage a simple todo list.
 
 ## Prerequisites
 

--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -59,7 +59,7 @@ templates:
       subdir: with-mastra
   - id: mcp
     title: "MCP server"
-    description: "An MCP server exposing CRUD contact tools over Lakebase Postgres, built with the Anthropic MCP SDK and Hono's streamable HTTP transport."
+    description: "An MCP server exposing CRUD contact tools over Lakebase Postgres on Neon, built with the Anthropic MCP SDK and Hono's streamable HTTP transport."
     tools:
       - Hono
       - Drizzle

--- a/bots/discord-bot-http/.agents/skills/neon/SKILL.md
+++ b/bots/discord-bot-http/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/bots/discord-bot-http/skills-lock.json
+++ b/bots/discord-bot-http/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-functions": {
       "source": "neondatabase/agent-skills",

--- a/bots/telegram-bot-http/.agents/skills/neon/SKILL.md
+++ b/bots/telegram-bot-http/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/bots/telegram-bot-http/skills-lock.json
+++ b/bots/telegram-bot-http/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-functions": {
       "source": "neondatabase/agent-skills",

--- a/bots/whatsapp-bot-http/.agents/skills/neon/SKILL.md
+++ b/bots/whatsapp-bot-http/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/bots/whatsapp-bot-http/skills-lock.json
+++ b/bots/whatsapp-bot-http/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-functions": {
       "source": "neondatabase/agent-skills",

--- a/with-ai-sdk/.agents/skills/neon/SKILL.md
+++ b/with-ai-sdk/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/with-ai-sdk/skills-lock.json
+++ b/with-ai-sdk/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-ai-gateway": {
       "source": "neondatabase/agent-skills",

--- a/with-encore/package.json
+++ b/with-encore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "neon-encore-example",
   "version": "1.0.0",
-  "description": "Example Encore.ts application with Lakebase Postgres",
+  "description": "Example Encore.ts application with Lakebase Postgres on Neon",
   "private": true,
   "type": "module",
   "scripts": {

--- a/with-files-sdk/.agents/skills/neon/SKILL.md
+++ b/with-files-sdk/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/with-files-sdk/skills-lock.json
+++ b/with-files-sdk/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-object-storage": {
       "source": "neondatabase/agent-skills",

--- a/with-hono/.agents/skills/neon/SKILL.md
+++ b/with-hono/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/with-hono/skills-lock.json
+++ b/with-hono/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-functions": {
       "source": "neondatabase/agent-skills",

--- a/with-mastra/.agents/skills/neon/SKILL.md
+++ b/with-mastra/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/with-mastra/skills-lock.json
+++ b/with-mastra/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-ai-gateway": {
       "source": "neondatabase/agent-skills",

--- a/with-mcp/.agents/skills/neon/SKILL.md
+++ b/with-mcp/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/with-mcp/skills-lock.json
+++ b/with-mcp/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-functions": {
       "source": "neondatabase/agent-skills",

--- a/with-realtime-chat/.agents/skills/neon/SKILL.md
+++ b/with-realtime-chat/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/with-realtime-chat/skills-lock.json
+++ b/with-realtime-chat/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-functions": {
       "source": "neondatabase/agent-skills",

--- a/with-realtime-sse/.agents/skills/neon/SKILL.md
+++ b/with-realtime-sse/.agents/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/with-realtime-sse/skills-lock.json
+++ b/with-realtime-sse/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "2d28135f0afcea994a5a9f34110c8c55f93f3a6515aee088d02169b3cb37c30f"
+      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
     },
     "neon-functions": {
       "source": "neondatabase/agent-skills",


### PR DESCRIPTION
Follow-up to [#242](https://github.com/neondatabase/examples/pull/242), applying the disambiguation rule the team settled in the naming thread after that PR merged. Third of three: [agent-skills#67](https://github.com/neondatabase/agent-skills/pull/67), [neon-for-agent-platforms#25](https://github.com/neondatabase/neon-for-agent-platforms/pull/25).

## Problem

Lakebase Postgres is reachable through Neon or through Databricks. The rule: **if a statement is accurate across both, don't disambiguate; if it only holds on the Neon path, say "Lakebase Postgres on Neon."** Name the path in descriptions and blurbs; skip it in body copy where context is already established.

Auditing all 51 occurrences in this repo produced a useful result: **every markdown file that says Lakebase Postgres also says Neon somewhere in the same file.** So the bulk of this repo is body copy with context established, and only strings that travel *detached from their file* actually needed the phrase.

Three did:

| File | Why it's detached |
|---|---|
| `with-encore/package.json` | the description travels to package registries — and this is the **only file in the repo that mentions Neon nowhere at all** |
| `auth/with-authjs-next/README.md` | the H1 *and* first paragraph name no path; Neon first appears down in prerequisites |
| `bootstrap.yaml` | the MCP template blurb, the only one of ten naming no Neon primitive |

```diff
# with-encore/package.json
- "description": "Example Encore.ts application with Lakebase Postgres"
+ "description": "Example Encore.ts application with Lakebase Postgres on Neon"

# auth/with-authjs-next/README.md
- # Next.js application with Lakebase Postgres and Auth.js authentication
+ # Next.js application with Lakebase Postgres on Neon and Auth.js authentication

# bootstrap.yaml — the blurb the neon CLI wizard prints
- An MCP server exposing CRUD contact tools over Lakebase Postgres, built with ...
+ An MCP server exposing CRUD contact tools over Lakebase Postgres on Neon, built with ...
```

The other nine `bootstrap.yaml` blurbs already say "Neon Functions", "the Neon AI Gateway", or "Neon Auth" in the same sentence.

## Left bare, deliberately

Beyond the body copy above, three cases where the phrase would actively damage the sentence:

- **10× "Update the environment variables with your OpenAI API Key and Lakebase Postgres URL."** Becomes "…Postgres URL on Neon", which reads as though the URL is on Neon rather than the database. These files say "the Neon database" and "A Neon account" a few lines up.
- **`with-nextjs-drizzle-local-vercel` renders "Lakebase Postgres on Vercel Edge with Drizzle ORM".** Would become "on Neon on Vercel Edge" — two stacked prepositions naming two different things.
- **3× bot stack labels, "Storage: Lakebase Postgres via Drizzle",** rendered into Discord, Telegram, and WhatsApp messages. Terse labels in a list whose sibling lines already say Neon Functions.

Also left alone: the 10 `ai/**/README.md` opening lines, where "the Neon database" appears one or two lines below, and the `route.ts` code comment.

## Verification

`with-encore/package.json` parses as JSON; `bootstrap.yaml` parses with its 10 entries intact. This repo has no CI — no `.github/`, no root `package.json` — so there is no gate to run. Nothing here is executable; the changes are one JSON string, one heading, one sentence, and one YAML blurb.

## The vendored skills, refreshed rather than edited

[agent-skills#67](https://github.com/neondatabase/agent-skills/pull/67) has merged, so [`857926f`](https://github.com/neondatabase/examples/commit/857926f) pulls it in:

```bash
npx skills update -p -y   # in each of the 13 consumer directories
```

Twenty files — 10 `neon/SKILL.md` copies and their 10 `skills-lock.json` entries. The content diff is one sentence per copy, nothing else:

```diff
- ...provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`...
+ ...provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`...
```

The three consumers under `neon-getting-started/` are unchanged: they vendor only `neon-postgres`, which #67 didn't touch. All thirteen refreshed **in place** this time, which confirms the `skillPath` backfill from [#242](https://github.com/neondatabase/examples/pull/242) worked — previously three of them refused `skills update` outright.

These are installed artifacts, so they were re-installed, not find-and-replaced. A hand-edit would leave each copy disagreeing with its recorded lock hash and the next `skills update` would silently revert it.

## For your attention

- **Nothing in this repo detects vendored-skill drift.** When `agent-skills` changes again, these 41 copies go stale silently — there's no equivalent of `agent-skills`'s own `validate:plugin-skills` check, and this repo has no `.github/` to host one. This is the second manual refresh in two days.
