### PR TITLE
feat: add example validator scripts

### DIFF
--- a/.github/scripts/validate-example.mjs
+++ b/.github/scripts/validate-example.mjs
@@ -25,12 +25,12 @@
 // Environment (diff mode):
 //   GITHUB_BASE_REF   base branch of the PR (e.g. "main"); falls back to "main"
 
-import { execFileSync } from 'node:child_process';
-import fs from 'node:fs';
-import path from 'node:path';
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 
-const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-  encoding: 'utf8',
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
 }).trim();
 
 const isCI = Boolean(process.env.GITHUB_ACTIONS);
@@ -38,7 +38,7 @@ const isCI = Boolean(process.env.GITHUB_ACTIONS);
 /** Emit a GitHub Actions error annotation (falls back to plain text locally). */
 function annotate(file, message) {
   if (isCI) {
-    const clean = message.replace(/\n/g, '%0A');
+    const clean = message.replace(/\n/g, "%0A");
     console.log(`::error file=${file}::${clean}`);
   }
 }
@@ -53,27 +53,27 @@ function fail(dir, file, message) {
 function hasAncestorPackageJson(dir) {
   let cur = path.dirname(dir);
   while (cur.startsWith(repoRoot) && cur !== repoRoot) {
-    if (fs.existsSync(path.join(cur, 'package.json'))) return true;
+    if (fs.existsSync(path.join(cur, "package.json"))) return true;
     cur = path.dirname(cur);
   }
   return false;
 }
 
 /** Recursively find keys whose value is empty ("", [], {}, or null). */
-function findEmptyFields(value, prefix = '') {
+function findEmptyFields(value, prefix = "") {
   const empties = [];
   if (value === null) {
-    empties.push(prefix || '(root)');
+    empties.push(prefix || "(root)");
     return empties;
   }
-  if (typeof value === 'string' && value.trim() === '') {
+  if (typeof value === "string" && value.trim() === "") {
     empties.push(prefix);
   } else if (Array.isArray(value)) {
     if (value.length === 0) empties.push(prefix);
-  } else if (typeof value === 'object') {
+  } else if (typeof value === "object") {
     const keys = Object.keys(value);
     if (keys.length === 0) {
-      empties.push(prefix || '(root)');
+      empties.push(prefix || "(root)");
     } else {
       for (const key of keys) {
         const next = prefix ? `${prefix}.${key}` : key;
@@ -92,9 +92,13 @@ function validatePackageJson(pkgPath, isRoot) {
   const rel = path.relative(repoRoot, pkgPath);
   let raw;
   try {
-    raw = fs.readFileSync(pkgPath, 'utf8');
+    raw = fs.readFileSync(pkgPath, "utf8");
   } catch (err) {
-    fail(path.dirname(pkgPath), rel, `Unable to read this file: ${err.message}`);
+    fail(
+      path.dirname(pkgPath),
+      rel,
+      `Unable to read this file: ${err.message}`,
+    );
     return;
   }
 
@@ -109,7 +113,7 @@ function validatePackageJson(pkgPath, isRoot) {
   const dir = path.dirname(pkgPath);
 
   // No version field.
-  if ('version' in pkg) {
+  if ("version" in pkg) {
     fail(dir, rel, `Remove the \`version\` field (found \`${pkg.version}\`).`);
   }
 
@@ -121,28 +125,43 @@ function validatePackageJson(pkgPath, isRoot) {
   // No empty fields anywhere in the object.
   const empties = findEmptyFields(pkg);
   if (empties.length > 0) {
-    const list = empties.map((e) => `\`${e}\``).join(', ');
+    const list = empties.map((e) => `\`${e}\``).join(", ");
     fail(dir, rel, `Remove empty field(s): ${list}.`);
   }
 
   // Meaningful, single-line description — required at the example root.
   if (isRoot) {
     const desc = pkg.description;
-    if (typeof desc !== 'string' || desc.trim() === '') {
-      fail(dir, rel, 'Add a non-empty `description`.');
+    if (typeof desc !== "string" || desc.trim() === "") {
+      fail(dir, rel, "Add a non-empty `description`.");
     } else {
       const trimmed = desc.trim();
       if (/[\r\n]/.test(desc)) {
-        fail(dir, rel, 'Make `description` a single line (no line breaks).');
+        fail(dir, rel, "Make `description` a single line (no line breaks).");
       }
       if (trimmed.length < 15) {
-        fail(dir, rel, '`description` is too short to be meaningful (min 15 chars).');
+        fail(
+          dir,
+          rel,
+          "`description` is too short to be meaningful (min 15 chars).",
+        );
       }
       if (trimmed.split(/\s+/).length < 3) {
-        fail(dir, rel, '`description` should be a meaningful phrase of at least 3 words.');
+        fail(
+          dir,
+          rel,
+          "`description` should be a meaningful phrase of at least 3 words.",
+        );
       }
-      if (pkg.name && trimmed.toLowerCase() === String(pkg.name).toLowerCase()) {
-        fail(dir, rel, '`description` must not simply repeat the package name.');
+      if (
+        pkg.name &&
+        trimmed.toLowerCase() === String(pkg.name).toLowerCase()
+      ) {
+        fail(
+          dir,
+          rel,
+          "`description` must not simply repeat the package name.",
+        );
       }
     }
   }
@@ -150,28 +169,36 @@ function validatePackageJson(pkgPath, isRoot) {
 
 /** Full validation of an example root directory. */
 function validateExampleRoot(dir) {
-  const pkgPath = path.join(dir, 'package.json');
+  const pkgPath = path.join(dir, "package.json");
   if (fs.existsSync(pkgPath)) {
     validatePackageJson(pkgPath, true);
   }
 
-  if (!fs.existsSync(path.join(dir, 'README.md'))) {
-    fail(dir, path.join(path.relative(repoRoot, dir), 'README.md'), 'Add a `README.md`.');
+  if (!fs.existsSync(path.join(dir, "README.md"))) {
+    fail(
+      dir,
+      path.join(path.relative(repoRoot, dir), "README.md"),
+      "Add a `README.md`.",
+    );
   }
 
-  if (!fs.existsSync(path.join(dir, '.env.example'))) {
-    fail(dir, path.join(path.relative(repoRoot, dir), '.env.example'), 'Add an `.env.example`.');
+  if (!fs.existsSync(path.join(dir, ".env.example"))) {
+    fail(
+      dir,
+      path.join(path.relative(repoRoot, dir), ".env.example"),
+      "Add an `.env.example`.",
+    );
   }
 }
 
 /** Diff mode: figure out which examples were added in this PR. */
 function collectAddedExampleRoots() {
-  const baseRef = process.env.GITHUB_BASE_REF || 'main';
+  const baseRef = process.env.GITHUB_BASE_REF || "main";
   let diffBase = baseRef;
   // Prefer the remote-tracking ref when it exists (CI checks out a detached HEAD).
   try {
-    execFileSync('git', ['rev-parse', '--verify', `origin/${baseRef}`], {
-      stdio: 'ignore',
+    execFileSync("git", ["rev-parse", "--verify", `origin/${baseRef}`], {
+      stdio: "ignore",
     });
     diffBase = `origin/${baseRef}`;
   } catch {
@@ -181,22 +208,25 @@ function collectAddedExampleRoots() {
   let out;
   try {
     out = execFileSync(
-      'git',
-      ['diff', '--name-only', '--diff-filter=A', `${diffBase}...HEAD`],
-      { encoding: 'utf8' },
+      "git",
+      ["diff", "--name-only", "--diff-filter=A", `${diffBase}...HEAD`],
+      { encoding: "utf8" },
     );
   } catch (err) {
     console.error(`Could not diff against ${diffBase}: ${err.message}`);
     process.exit(1);
   }
 
-  const addedFiles = out.split('\n').map((l) => l.trim()).filter(Boolean);
+  const addedFiles = out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
 
   const roots = new Set();
   const subPackages = new Set();
 
   for (const file of addedFiles) {
-    if (path.basename(file) !== 'package.json') continue;
+    if (path.basename(file) !== "package.json") continue;
     const absDir = path.join(repoRoot, path.dirname(file));
     if (hasAncestorPackageJson(absDir)) {
       subPackages.add(absDir); // nested sub-package (e.g. web/)
@@ -209,7 +239,7 @@ function collectAddedExampleRoots() {
 }
 
 /** Marker so the workflow can find and update its own sticky comment. */
-const COMMENT_MARKER = '<!-- validate-example-bot -->';
+const COMMENT_MARKER = "<!-- validate-example-bot -->";
 
 /**
  * Render a repo-relative path as a markdown link to that path in the PR head,
@@ -229,12 +259,20 @@ function pathLink(rel) {
 
 /** Build the markdown body posted as a PR comment. */
 function buildReport(validated, ok) {
-  const lines = [COMMENT_MARKER, '## Pre-review requirements'];
+  const lines = [COMMENT_MARKER, "## Pre-review requirements"];
   if (ok) {
-    lines.push('', '✅ All checks passed for the example(s) added in this PR:', '');
+    lines.push(
+      "",
+      "✅ All checks passed for the example(s) added in this PR:",
+      "",
+    );
     for (const name of validated) lines.push(`- ${pathLink(name)}`);
   } else {
-    lines.push('', `❌ Found the following ${problems.length} issue(s) in this PR:`, '');
+    lines.push(
+      "",
+      `❌ Found the following ${problems.length} issue(s) in this PR:`,
+      "",
+    );
     // Group problems by the file they belong to.
     const byFile = new Map();
     for (const p of problems) {
@@ -243,12 +281,12 @@ function buildReport(validated, ok) {
       byFile.get(key).push(p.message);
     }
     for (const [file, msgs] of byFile) {
-      lines.push(`**${pathLink(file)}**`, '');
+      lines.push(`**${pathLink(file)}**`, "");
       for (const m of msgs) lines.push(`- [ ] ${m}`);
-      lines.push('');
+      lines.push("");
     }
   }
-  return lines.join('\n').trimEnd();
+  return lines.join("\n").trimEnd();
 }
 
 /** Write the markdown report and tell the workflow whether to post it. */
@@ -258,7 +296,7 @@ function emitReport(validated, ok) {
   // Comment only when we actually validated something in this PR.
   const shouldComment = validated.length > 0;
   if (shouldComment && reportPath) {
-    fs.writeFileSync(reportPath, buildReport(validated, ok) + '\n');
+    fs.writeFileSync(reportPath, buildReport(validated, ok) + "\n");
   }
   if (outPath) {
     fs.appendFileSync(outPath, `should_comment=${shouldComment}\n`);
@@ -266,7 +304,7 @@ function emitReport(validated, ok) {
 }
 
 function main() {
-  const args = process.argv.slice(2).filter((a) => !a.startsWith('-'));
+  const args = process.argv.slice(2).filter((a) => !a.startsWith("-"));
   const validated = []; // human-readable names of what we validated
 
   if (args.length > 0) {
@@ -284,13 +322,15 @@ function main() {
     const { roots, subPackages } = collectAddedExampleRoots();
 
     if (roots.length === 0 && subPackages.length === 0) {
-      console.log('No newly added example detected in this PR. Nothing to validate.');
+      console.log(
+        "No newly added example detected in this PR. Nothing to validate.",
+      );
       emitReport(validated, true);
       return;
     }
 
     for (const dir of roots) {
-      const name = path.relative(repoRoot, dir) || '.';
+      const name = path.relative(repoRoot, dir) || ".";
       console.log(`Validating new example: ${name}`);
       validated.push(name);
       validateExampleRoot(dir);
@@ -300,7 +340,7 @@ function main() {
       const name = path.relative(repoRoot, dir);
       console.log(`Validating sub-package: ${name}`);
       validated.push(name);
-      validatePackageJson(path.join(dir, 'package.json'), false);
+      validatePackageJson(path.join(dir, "package.json"), false);
     }
   }
 
@@ -315,7 +355,7 @@ function main() {
     process.exit(1);
   }
 
-  console.log('\n✓ All checks passed.');
+  console.log("\n✓ All checks passed.");
 }
 
 main();

--- a/.github/scripts/validate-example.mjs
+++ b/.github/scripts/validate-example.mjs
@@ -270,7 +270,7 @@ function buildReport(validated, ok) {
   } else {
     lines.push(
       "",
-      `❌ Found the following ${problems.length} issue(s) in this PR:`,
+      `Found the following ${problems.length} ${problems.length > 1 ? "issues" : "issue"} in this PR:`,
       "",
     );
     // Group problems by the file they belong to.

--- a/.github/scripts/validate-example.mjs
+++ b/.github/scripts/validate-example.mjs
@@ -122,8 +122,9 @@ function validatePackageJson(pkgPath, isRoot) {
     fail(dir, rel, 'Set `"private": true`.');
   }
 
-  // No empty fields anywhere in the object.
-  const empties = findEmptyFields(pkg);
+  // No empty fields anywhere in the object. `description` is required to be
+  // present (checked below), so an empty one is reported as "add", not "remove".
+  const empties = findEmptyFields(pkg).filter((e) => e !== "description");
   if (empties.length > 0) {
     const list = empties.map((e) => `\`${e}\``).join(", ");
     fail(dir, rel, `Remove empty field(s): ${list}.`);

--- a/.github/scripts/validate-example.mjs
+++ b/.github/scripts/validate-example.mjs
@@ -122,7 +122,7 @@ function validatePackageJson(pkgPath, isRoot) {
   const empties = findEmptyFields(pkg);
   if (empties.length > 0) {
     const list = empties.map((e) => `\`${e}\``).join(', ');
-    fail(dir, rel, `Remove or fill empty field(s): ${list}.`);
+    fail(dir, rel, `Remove empty field(s): ${list}.`);
   }
 
   // Meaningful, single-line description — required at the example root.
@@ -213,9 +213,9 @@ const COMMENT_MARKER = '<!-- validate-example-bot -->';
 
 /**
  * Render a repo-relative path as a markdown link to that path in the PR head,
- * when REPO_URL + HEAD_SHA are provided (CI). Existing files link to the blob;
- * paths that don't exist yet (e.g. a missing README.md) link to the directory
- * listing so the reader lands somewhere real. Falls back to inline code.
+ * when REPO_URL + HEAD_SHA are provided (CI). Only existing files are linked
+ * (to the blob); paths that don't exist yet (e.g. a missing README.md) render
+ * as plain inline code. Also falls back to inline code outside CI.
  */
 function pathLink(rel) {
   const label = `\`${rel}\``;
@@ -223,11 +223,8 @@ function pathLink(rel) {
   const sha = process.env.HEAD_SHA;
   if (!repoUrl || !sha) return label;
   const abs = path.join(repoRoot, rel);
-  if (fs.existsSync(abs)) {
-    return `[${label}](${repoUrl}/blob/${sha}/${rel})`;
-  }
-  const dir = path.dirname(rel);
-  return `[${label}](${repoUrl}/tree/${sha}/${dir})`;
+  if (!fs.existsSync(abs)) return label;
+  return `[${label}](${repoUrl}/blob/${sha}/${rel})`;
 }
 
 /** Build the markdown body posted as a PR comment. */
@@ -237,7 +234,7 @@ function buildReport(validated, ok) {
     lines.push('', '✅ All checks passed for the example(s) added in this PR:', '');
     for (const name of validated) lines.push(`- ${pathLink(name)}`);
   } else {
-    lines.push('', `❌ Found ${problems.length} problem(s) in the example(s) added in this PR.`, '');
+    lines.push('', `❌ Found the following ${problems.length} issue(s) in this PR:`, '');
     // Group problems by the file they belong to.
     const byFile = new Map();
     for (const p of problems) {
@@ -247,7 +244,7 @@ function buildReport(validated, ok) {
     }
     for (const [file, msgs] of byFile) {
       lines.push(`**${pathLink(file)}**`, '');
-      for (const m of msgs) lines.push(`- ${m}`);
+      for (const m of msgs) lines.push(`- [ ] ${m}`);
       lines.push('');
     }
   }
@@ -311,7 +308,7 @@ function main() {
   emitReport(validated, ok);
 
   if (!ok) {
-    console.error(`\n${problems.length} validation problem(s) found:\n`);
+    console.error(`\n${problems.length} validation issue(s) found:\n`);
     for (const p of problems) {
       console.error(`  ✗ ${p.message}`);
     }

--- a/.github/scripts/validate-example.mjs
+++ b/.github/scripts/validate-example.mjs
@@ -19,8 +19,8 @@
 // implements, so it runs the same under `bun` or `node`.
 //
 // Usage:
-//   bun scripts/validate-example.mjs                # diff mode (CI): validate examples added vs. the base ref
-//   bun scripts/validate-example.mjs with-foo bots/bar   # validate the given example roots directly
+//   bun .github/scripts/validate-example.mjs                # diff mode (CI): validate examples added vs. the base ref
+//   bun .github/scripts/validate-example.mjs with-foo bots/bar   # validate the given example roots directly
 //
 // Environment (diff mode):
 //   GITHUB_BASE_REF   base branch of the PR (e.g. "main"); falls back to "main"
@@ -94,7 +94,7 @@ function validatePackageJson(pkgPath, isRoot) {
   try {
     raw = fs.readFileSync(pkgPath, 'utf8');
   } catch (err) {
-    fail(path.dirname(pkgPath), rel, `Unable to read ${rel}: ${err.message}`);
+    fail(path.dirname(pkgPath), rel, `Unable to read this file: ${err.message}`);
     return;
   }
 
@@ -102,7 +102,7 @@ function validatePackageJson(pkgPath, isRoot) {
   try {
     pkg = JSON.parse(raw);
   } catch (err) {
-    fail(path.dirname(pkgPath), rel, `${rel} is not valid JSON: ${err.message}`);
+    fail(path.dirname(pkgPath), rel, `Not valid JSON: ${err.message}`);
     return;
   }
 
@@ -110,38 +110,39 @@ function validatePackageJson(pkgPath, isRoot) {
 
   // No version field.
   if ('version' in pkg) {
-    fail(dir, rel, `${rel} must not declare a "version" field (found "${pkg.version}").`);
+    fail(dir, rel, `Remove the \`version\` field (found \`${pkg.version}\`).`);
   }
 
   // private: true must be present.
   if (pkg.private !== true) {
-    fail(dir, rel, `${rel} must set "private": true.`);
+    fail(dir, rel, 'Set `"private": true`.');
   }
 
   // No empty fields anywhere in the object.
   const empties = findEmptyFields(pkg);
   if (empties.length > 0) {
-    fail(dir, rel, `${rel} has empty field(s): ${empties.join(', ')}. Remove them or give them a value.`);
+    const list = empties.map((e) => `\`${e}\``).join(', ');
+    fail(dir, rel, `Remove or fill empty field(s): ${list}.`);
   }
 
   // Meaningful, single-line description — required at the example root.
   if (isRoot) {
     const desc = pkg.description;
     if (typeof desc !== 'string' || desc.trim() === '') {
-      fail(dir, rel, `${rel} must include a non-empty "description".`);
+      fail(dir, rel, 'Add a non-empty `description`.');
     } else {
       const trimmed = desc.trim();
       if (/[\r\n]/.test(desc)) {
-        fail(dir, rel, `${rel} "description" must be a single line (no line breaks).`);
+        fail(dir, rel, 'Make `description` a single line (no line breaks).');
       }
       if (trimmed.length < 15) {
-        fail(dir, rel, `${rel} "description" is too short to be meaningful (min 15 chars).`);
+        fail(dir, rel, '`description` is too short to be meaningful (min 15 chars).');
       }
       if (trimmed.split(/\s+/).length < 3) {
-        fail(dir, rel, `${rel} "description" should be a meaningful phrase of at least 3 words.`);
+        fail(dir, rel, '`description` should be a meaningful phrase of at least 3 words.');
       }
       if (pkg.name && trimmed.toLowerCase() === String(pkg.name).toLowerCase()) {
-        fail(dir, rel, `${rel} "description" must not simply repeat the package name.`);
+        fail(dir, rel, '`description` must not simply repeat the package name.');
       }
     }
   }
@@ -149,19 +150,17 @@ function validatePackageJson(pkgPath, isRoot) {
 
 /** Full validation of an example root directory. */
 function validateExampleRoot(dir) {
-  const rel = path.relative(repoRoot, dir) || '.';
-
   const pkgPath = path.join(dir, 'package.json');
   if (fs.existsSync(pkgPath)) {
     validatePackageJson(pkgPath, true);
   }
 
   if (!fs.existsSync(path.join(dir, 'README.md'))) {
-    fail(dir, path.join(rel, 'README.md'), `${rel} is missing a README.md.`);
+    fail(dir, path.join(path.relative(repoRoot, dir), 'README.md'), 'Add a `README.md`.');
   }
 
   if (!fs.existsSync(path.join(dir, '.env.example'))) {
-    fail(dir, path.join(rel, '.env.example'), `${rel} is missing an .env.example.`);
+    fail(dir, path.join(path.relative(repoRoot, dir), '.env.example'), 'Add an `.env.example`.');
   }
 }
 
@@ -212,12 +211,31 @@ function collectAddedExampleRoots() {
 /** Marker so the workflow can find and update its own sticky comment. */
 const COMMENT_MARKER = '<!-- validate-example-bot -->';
 
+/**
+ * Render a repo-relative path as a markdown link to that path in the PR head,
+ * when REPO_URL + HEAD_SHA are provided (CI). Existing files link to the blob;
+ * paths that don't exist yet (e.g. a missing README.md) link to the directory
+ * listing so the reader lands somewhere real. Falls back to inline code.
+ */
+function pathLink(rel) {
+  const label = `\`${rel}\``;
+  const repoUrl = process.env.REPO_URL;
+  const sha = process.env.HEAD_SHA;
+  if (!repoUrl || !sha) return label;
+  const abs = path.join(repoRoot, rel);
+  if (fs.existsSync(abs)) {
+    return `[${label}](${repoUrl}/blob/${sha}/${rel})`;
+  }
+  const dir = path.dirname(rel);
+  return `[${label}](${repoUrl}/tree/${sha}/${dir})`;
+}
+
 /** Build the markdown body posted as a PR comment. */
 function buildReport(validated, ok) {
-  const lines = [COMMENT_MARKER, '## Example validator'];
+  const lines = [COMMENT_MARKER, '## Pre-review requirements'];
   if (ok) {
     lines.push('', '✅ All checks passed for the example(s) added in this PR:', '');
-    for (const name of validated) lines.push(`- \`${name}\``);
+    for (const name of validated) lines.push(`- ${pathLink(name)}`);
   } else {
     lines.push('', `❌ Found ${problems.length} problem(s) in the example(s) added in this PR.`, '');
     // Group problems by the file they belong to.
@@ -228,21 +246,12 @@ function buildReport(validated, ok) {
       byFile.get(key).push(p.message);
     }
     for (const [file, msgs] of byFile) {
-      lines.push(`**\`${file}\`**`);
+      lines.push(`**${pathLink(file)}**`, '');
       for (const m of msgs) lines.push(`- ${m}`);
       lines.push('');
     }
-    lines.push('---', '');
-    lines.push('Every added example must satisfy:');
-    lines.push('- `package.json` has **no `version`** field');
-    lines.push('- `package.json` sets **`private: true`**');
-    lines.push('- `package.json` has **no empty fields** (`""`, `[]`, `{}`, `null`)');
-    lines.push('- `package.json` has a **meaningful, single-line `description`**');
-    lines.push('- a **`README.md`** is present');
-    lines.push('- an **`.env.example`** is present');
-    lines.push('', 'See `CONTRIBUTING.md` for the example conventions.');
   }
-  return lines.join('\n');
+  return lines.join('\n').trimEnd();
 }
 
 /** Write the markdown report and tell the workflow whether to post it. */
@@ -306,11 +315,10 @@ function main() {
     for (const p of problems) {
       console.error(`  ✗ ${p.message}`);
     }
-    console.error('\nSee CONTRIBUTING.md for the example conventions.');
     process.exit(1);
   }
 
-  console.log('\n✓ All example checks passed.');
+  console.log('\n✓ All checks passed.');
 }
 
 main();

--- a/.github/workflows/validate-example.yml
+++ b/.github/workflows/validate-example.yml
@@ -1,0 +1,64 @@
+name: Validate example
+
+# Runs on every pull request. The validator only acts on examples that are
+# newly ADDED in the PR (keyed off a new package.json), so PRs that merely edit
+# existing examples are unaffected. Whatever it finds is posted to the PR as a
+# single sticky comment (updated in place on each push).
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so we can diff against the PR base ref.
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Ensure base ref is available
+        run: git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}"
+
+      - name: Validate added examples
+        id: validate
+        continue-on-error: true
+        env:
+          VALIDATION_REPORT: ${{ runner.temp }}/validation-report.md
+        run: bun scripts/validate-example.mjs
+
+      - name: Comment result on PR
+        if: steps.validate.outputs.should_comment == 'true'
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: ${{ runner.temp }}/validation-report.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- validate-example-bot -->';
+            const body = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Fail if validation found problems
+        if: steps.validate.outcome == 'failure'
+        run: |
+          echo "Example validation failed. See the PR comment for details."
+          exit 1

--- a/.github/workflows/validate-example.yml
+++ b/.github/workflows/validate-example.yml
@@ -5,6 +5,7 @@ name: Validate example
 # existing examples are unaffected. Whatever it finds is posted to the PR as a
 # single sticky comment (updated in place on each push).
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -35,7 +36,10 @@ jobs:
         continue-on-error: true
         env:
           VALIDATION_REPORT: ${{ runner.temp }}/validation-report.md
-        run: bun scripts/validate-example.mjs
+          # Used to build links to the changed files in the PR head.
+          REPO_URL: ${{ github.event.pull_request.head.repo.html_url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bun .github/scripts/validate-example.mjs
 
       - name: Comment result on PR
         if: steps.validate.outputs.should_comment == 'true'

--- a/scripts/validate-example.mjs
+++ b/scripts/validate-example.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env bun
+// Validator for newly added examples.
+//
+// It enforces the contribution rules for an example directory:
+//   - package.json (if present) must NOT have a `version` field
+//   - package.json (if present) must have `private: true`
+//   - package.json (if present) must have no empty fields ("", [], {}, null)
+//   - package.json (if present) must have a meaningful, single-line `description`
+//   - README.md must be present at the example root
+//   - .env.example must be present at the example root
+//
+// Scope: by design this only checks examples that are ADDED in a pull request,
+// keyed off a newly added package.json. Edits to existing examples are left
+// alone (many predate these rules), and nested sub-packages such as `web/`
+// are validated for the package.json field rules but are not required to carry
+// their own README.md / .env.example.
+//
+// Runtime: Bun. The script relies only on `node:` built-ins, which Bun
+// implements, so it runs the same under `bun` or `node`.
+//
+// Usage:
+//   bun scripts/validate-example.mjs                # diff mode (CI): validate examples added vs. the base ref
+//   bun scripts/validate-example.mjs with-foo bots/bar   # validate the given example roots directly
+//
+// Environment (diff mode):
+//   GITHUB_BASE_REF   base branch of the PR (e.g. "main"); falls back to "main"
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  encoding: 'utf8',
+}).trim();
+
+const isCI = Boolean(process.env.GITHUB_ACTIONS);
+
+/** Emit a GitHub Actions error annotation (falls back to plain text locally). */
+function annotate(file, message) {
+  if (isCI) {
+    const clean = message.replace(/\n/g, '%0A');
+    console.log(`::error file=${file}::${clean}`);
+  }
+}
+
+const problems = [];
+function fail(dir, file, message) {
+  problems.push({ dir, file, message });
+  annotate(file, message);
+}
+
+/** True if any ancestor directory of `dir` (up to repo root) holds a package.json. */
+function hasAncestorPackageJson(dir) {
+  let cur = path.dirname(dir);
+  while (cur.startsWith(repoRoot) && cur !== repoRoot) {
+    if (fs.existsSync(path.join(cur, 'package.json'))) return true;
+    cur = path.dirname(cur);
+  }
+  return false;
+}
+
+/** Recursively find keys whose value is empty ("", [], {}, or null). */
+function findEmptyFields(value, prefix = '') {
+  const empties = [];
+  if (value === null) {
+    empties.push(prefix || '(root)');
+    return empties;
+  }
+  if (typeof value === 'string' && value.trim() === '') {
+    empties.push(prefix);
+  } else if (Array.isArray(value)) {
+    if (value.length === 0) empties.push(prefix);
+  } else if (typeof value === 'object') {
+    const keys = Object.keys(value);
+    if (keys.length === 0) {
+      empties.push(prefix || '(root)');
+    } else {
+      for (const key of keys) {
+        const next = prefix ? `${prefix}.${key}` : key;
+        empties.push(...findEmptyFields(value[key], next));
+      }
+    }
+  }
+  return empties;
+}
+
+/**
+ * Validate a single package.json.
+ * @param {boolean} isRoot whether this is the example root (extra rules apply)
+ */
+function validatePackageJson(pkgPath, isRoot) {
+  const rel = path.relative(repoRoot, pkgPath);
+  let raw;
+  try {
+    raw = fs.readFileSync(pkgPath, 'utf8');
+  } catch (err) {
+    fail(path.dirname(pkgPath), rel, `Unable to read ${rel}: ${err.message}`);
+    return;
+  }
+
+  let pkg;
+  try {
+    pkg = JSON.parse(raw);
+  } catch (err) {
+    fail(path.dirname(pkgPath), rel, `${rel} is not valid JSON: ${err.message}`);
+    return;
+  }
+
+  const dir = path.dirname(pkgPath);
+
+  // No version field.
+  if ('version' in pkg) {
+    fail(dir, rel, `${rel} must not declare a "version" field (found "${pkg.version}").`);
+  }
+
+  // private: true must be present.
+  if (pkg.private !== true) {
+    fail(dir, rel, `${rel} must set "private": true.`);
+  }
+
+  // No empty fields anywhere in the object.
+  const empties = findEmptyFields(pkg);
+  if (empties.length > 0) {
+    fail(dir, rel, `${rel} has empty field(s): ${empties.join(', ')}. Remove them or give them a value.`);
+  }
+
+  // Meaningful, single-line description — required at the example root.
+  if (isRoot) {
+    const desc = pkg.description;
+    if (typeof desc !== 'string' || desc.trim() === '') {
+      fail(dir, rel, `${rel} must include a non-empty "description".`);
+    } else {
+      const trimmed = desc.trim();
+      if (/[\r\n]/.test(desc)) {
+        fail(dir, rel, `${rel} "description" must be a single line (no line breaks).`);
+      }
+      if (trimmed.length < 15) {
+        fail(dir, rel, `${rel} "description" is too short to be meaningful (min 15 chars).`);
+      }
+      if (trimmed.split(/\s+/).length < 3) {
+        fail(dir, rel, `${rel} "description" should be a meaningful phrase of at least 3 words.`);
+      }
+      if (pkg.name && trimmed.toLowerCase() === String(pkg.name).toLowerCase()) {
+        fail(dir, rel, `${rel} "description" must not simply repeat the package name.`);
+      }
+    }
+  }
+}
+
+/** Full validation of an example root directory. */
+function validateExampleRoot(dir) {
+  const rel = path.relative(repoRoot, dir) || '.';
+
+  const pkgPath = path.join(dir, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    validatePackageJson(pkgPath, true);
+  }
+
+  if (!fs.existsSync(path.join(dir, 'README.md'))) {
+    fail(dir, path.join(rel, 'README.md'), `${rel} is missing a README.md.`);
+  }
+
+  if (!fs.existsSync(path.join(dir, '.env.example'))) {
+    fail(dir, path.join(rel, '.env.example'), `${rel} is missing an .env.example.`);
+  }
+}
+
+/** Diff mode: figure out which examples were added in this PR. */
+function collectAddedExampleRoots() {
+  const baseRef = process.env.GITHUB_BASE_REF || 'main';
+  let diffBase = baseRef;
+  // Prefer the remote-tracking ref when it exists (CI checks out a detached HEAD).
+  try {
+    execFileSync('git', ['rev-parse', '--verify', `origin/${baseRef}`], {
+      stdio: 'ignore',
+    });
+    diffBase = `origin/${baseRef}`;
+  } catch {
+    // fall back to the bare ref
+  }
+
+  let out;
+  try {
+    out = execFileSync(
+      'git',
+      ['diff', '--name-only', '--diff-filter=A', `${diffBase}...HEAD`],
+      { encoding: 'utf8' },
+    );
+  } catch (err) {
+    console.error(`Could not diff against ${diffBase}: ${err.message}`);
+    process.exit(1);
+  }
+
+  const addedFiles = out.split('\n').map((l) => l.trim()).filter(Boolean);
+
+  const roots = new Set();
+  const subPackages = new Set();
+
+  for (const file of addedFiles) {
+    if (path.basename(file) !== 'package.json') continue;
+    const absDir = path.join(repoRoot, path.dirname(file));
+    if (hasAncestorPackageJson(absDir)) {
+      subPackages.add(absDir); // nested sub-package (e.g. web/)
+    } else {
+      roots.add(absDir); // example root
+    }
+  }
+
+  return { roots: [...roots], subPackages: [...subPackages], addedFiles };
+}
+
+/** Marker so the workflow can find and update its own sticky comment. */
+const COMMENT_MARKER = '<!-- validate-example-bot -->';
+
+/** Build the markdown body posted as a PR comment. */
+function buildReport(validated, ok) {
+  const lines = [COMMENT_MARKER, '## Example validator'];
+  if (ok) {
+    lines.push('', '✅ All checks passed for the example(s) added in this PR:', '');
+    for (const name of validated) lines.push(`- \`${name}\``);
+  } else {
+    lines.push('', `❌ Found ${problems.length} problem(s) in the example(s) added in this PR.`, '');
+    // Group problems by the file they belong to.
+    const byFile = new Map();
+    for (const p of problems) {
+      const key = p.file;
+      if (!byFile.has(key)) byFile.set(key, []);
+      byFile.get(key).push(p.message);
+    }
+    for (const [file, msgs] of byFile) {
+      lines.push(`**\`${file}\`**`);
+      for (const m of msgs) lines.push(`- ${m}`);
+      lines.push('');
+    }
+    lines.push('---', '');
+    lines.push('Every added example must satisfy:');
+    lines.push('- `package.json` has **no `version`** field');
+    lines.push('- `package.json` sets **`private: true`**');
+    lines.push('- `package.json` has **no empty fields** (`""`, `[]`, `{}`, `null`)');
+    lines.push('- `package.json` has a **meaningful, single-line `description`**');
+    lines.push('- a **`README.md`** is present');
+    lines.push('- an **`.env.example`** is present');
+    lines.push('', 'See `CONTRIBUTING.md` for the example conventions.');
+  }
+  return lines.join('\n');
+}
+
+/** Write the markdown report and tell the workflow whether to post it. */
+function emitReport(validated, ok) {
+  const reportPath = process.env.VALIDATION_REPORT;
+  const outPath = process.env.GITHUB_OUTPUT;
+  // Comment only when we actually validated something in this PR.
+  const shouldComment = validated.length > 0;
+  if (shouldComment && reportPath) {
+    fs.writeFileSync(reportPath, buildReport(validated, ok) + '\n');
+  }
+  if (outPath) {
+    fs.appendFileSync(outPath, `should_comment=${shouldComment}\n`);
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2).filter((a) => !a.startsWith('-'));
+  const validated = []; // human-readable names of what we validated
+
+  if (args.length > 0) {
+    // Explicit mode: validate the given directories as example roots.
+    for (const arg of args) {
+      const dir = path.resolve(repoRoot, arg);
+      if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+        fail(dir, arg, `${arg} is not a directory.`);
+        continue;
+      }
+      validated.push(path.relative(repoRoot, dir) || arg);
+      validateExampleRoot(dir);
+    }
+  } else {
+    const { roots, subPackages } = collectAddedExampleRoots();
+
+    if (roots.length === 0 && subPackages.length === 0) {
+      console.log('No newly added example detected in this PR. Nothing to validate.');
+      emitReport(validated, true);
+      return;
+    }
+
+    for (const dir of roots) {
+      const name = path.relative(repoRoot, dir) || '.';
+      console.log(`Validating new example: ${name}`);
+      validated.push(name);
+      validateExampleRoot(dir);
+    }
+    // Sub-packages get the package.json field rules only (no README/.env.example).
+    for (const dir of subPackages) {
+      const name = path.relative(repoRoot, dir);
+      console.log(`Validating sub-package: ${name}`);
+      validated.push(name);
+      validatePackageJson(path.join(dir, 'package.json'), false);
+    }
+  }
+
+  const ok = problems.length === 0;
+  emitReport(validated, ok);
+
+  if (!ok) {
+    console.error(`\n${problems.length} validation problem(s) found:\n`);
+    for (const p of problems) {
+      console.error(`  ✗ ${p.message}`);
+    }
+    console.error('\nSee CONTRIBUTING.md for the example conventions.');
+    process.exit(1);
+  }
+
+  console.log('\n✓ All example checks passed.');
+}
+
+main();


### PR DESCRIPTION
In #252, I saw that there are lot of examples that didn't follow the usual convention of this repository.

Tested this PR on https://github.com/rishi-raj-jain/n-examples/pull/1 to make sure that:

Whenever a new PR with a package.json is created, it:

- checks if README.md exists
- checks if .env.example exists
- checks if private true is set in package.json
- checks if version is NOT set in package.json
- checks if description is set in package.json
- checks if empty fields are present in package.json