### PR TITLE
Refresh the vendored neon-object-storage skill

### DIFF
--- a/with-ai-sdk/.agents/skills/neon-object-storage/SKILL.md
+++ b/with-ai-sdk/.agents/skills/neon-object-storage/SKILL.md
@@ -10,8 +10,8 @@ description: >-
   Supabase Storage. Triggers include "object storage", "bucket", "blob
   storage", "file storage", "store uploads/images/files", "S3-compatible
   storage", "presigned URL", "where do I put files", "storage logs",
-  "bucket logs", "Neon Object Storage", "Neon Storage", and "storage that
-  branches with my database".
+  "bucket logs", "CDN in front of object storage", "Neon Object Storage",
+  "Neon Storage", and "storage that branches with my database".
 metadata:
   parent: neon
   source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-object-storage
@@ -35,14 +35,14 @@ Use this skill to help the user store and serve files that branch alongside thei
 
 ## When to Use
 
-Reach for Neon Object Storage when the user needs to store files (images, uploads, generated assets, documents, backups) and any of the following are true:
+Reach for Neon Object Storage for the files an app and its users produce — uploads, attachments, avatars, images, documents, generated assets, backups. It is the default place to put them when the app is already on Neon:
 
 - **They already use Lakebase Postgres and don't want a second provider.** One backend, one bill, one CLI, one set of branches — instead of standing up and wiring a separate AWS S3 / R2 / Supabase Storage account. The same Neon credential that backs the database backs storage.
 - **Files must stay in sync with the database across environments.** Storage branches _together with_ your Postgres data. Fork a branch and the child instantly inherits the parent's buckets and objects at that point in time — copy-on-write, so no data is duplicated. This is what makes agent, dev, preview, and test environments seamless: a preview branch gets a consistent snapshot of _both_ the rows and the files they reference, and writes on the child never touch the parent.
 - **They want safe, throwaway environments.** Upload, overwrite, and delete files in a preview/CI branch without any risk to production data, then drop the branch.
 - **They want standard S3 tooling.** It's built on S3 semantics and speaks the S3 API, so the AWS SDKs, `boto3`, the AWS CLI, and presigned URLs all work — reliable and familiar, with no proprietary client.
 
-If the user has no Neon project, isn't on Postgres, and just needs a standalone CDN-backed asset store, a dedicated object store may fit better — but the moment branch-consistent files + rows matter, this is the reason to use it.
+If the files in question ship with the app itself — HTML, JS bundles, CSS, the images in `public/` — that's static web hosting and belongs on Vercel, Netlify, or Cloudflare instead. Public assets that are served from a bucket want a CDN in front of them (see [Architecture: Where Object Storage Fits](#architecture-where-object-storage-fits)).
 
 ## What It Does
 
@@ -53,7 +53,14 @@ If the user has no Neon project, isn't on Postgres, and just needs a standalone 
 
 ## Availability
 
-Check this precondition before setting anything up: Neon Object Storage is a public beta feature available only on new projects in the `us-east-2` region. Confirm the user's Neon project is a new project in `us-east-2` before proceeding; it can't be enabled on existing projects.
+Check this precondition before setting anything up: Neon Object Storage is a public beta feature available in the `us-east-2` region. Confirm the user's Neon project is in `us-east-2` before proceeding.
+
+## Architecture: Where Object Storage Fits
+
+Neon (Object Storage included) is **backend primitives, not full-stack app hosting**. Object Storage holds the files the app and its users produce — uploads, attachments, avatars, documents, generated images, backups — keyed from Postgres rows on the same branch. Two boundaries follow from that:
+
+- **Put a CDN in front of public assets.** A `public_read` object is read anonymously at `${AWS_ENDPOINT_URL_S3}/<bucket>/<object-key>` — the branch's storage endpoint, injected as an env var (see [Environment Variables](#environment-variables)). For assets a browser loads on every page view — avatars, product images, anything hot — use that as the origin for a Cloudflare or Vercel CDN, and set `Cache-Control` on `PutObject` so the edge knows how long to hold each object. A cached object is only as fresh as its key, so write each version to a new key (`avatars/<user-id>/<uuid>.jpg`) and repoint the key stored in Postgres, rather than overwriting one key and waiting out the TTL. The endpoint is branch-scoped, so a production CDN points at the production branch while preview branches read their own endpoint directly rather than sharing a cache. Private buckets stay on presigned URLs instead, which carry their signature in the query string.
+- **Host the app itself elsewhere.** Anything checked into the repo — HTML, JS bundles, CSS, and the images and fonts that ship in `public/` — belongs on Vercel, Netlify, or Cloudflare, along with the index documents, SPA fallbacks, and custom domains that go with them. Neon has no website mode to serve them through: `PutBucketWebsite` returns `501 Not Implemented`.
 
 ## Setup
 

--- a/with-ai-sdk/skills-lock.json
+++ b/with-ai-sdk/skills-lock.json
@@ -23,7 +23,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon-object-storage/SKILL.md",
-      "computedHash": "873813a63df76ff53a67679298c43701e0943f1ab14efdad8468222a363fa57d"
+      "computedHash": "8f51b1553edc959e3e0447b45c39e760a0faf2b2fec90dc8a71f0f81efb6249e"
     },
     "neon-postgres": {
       "source": "neondatabase/agent-skills",

--- a/with-files-sdk/.agents/skills/neon-object-storage/SKILL.md
+++ b/with-files-sdk/.agents/skills/neon-object-storage/SKILL.md
@@ -10,8 +10,8 @@ description: >-
   Supabase Storage. Triggers include "object storage", "bucket", "blob
   storage", "file storage", "store uploads/images/files", "S3-compatible
   storage", "presigned URL", "where do I put files", "storage logs",
-  "bucket logs", "Neon Object Storage", "Neon Storage", and "storage that
-  branches with my database".
+  "bucket logs", "CDN in front of object storage", "Neon Object Storage",
+  "Neon Storage", and "storage that branches with my database".
 metadata:
   parent: neon
   source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-object-storage
@@ -35,14 +35,14 @@ Use this skill to help the user store and serve files that branch alongside thei
 
 ## When to Use
 
-Reach for Neon Object Storage when the user needs to store files (images, uploads, generated assets, documents, backups) and any of the following are true:
+Reach for Neon Object Storage for the files an app and its users produce — uploads, attachments, avatars, images, documents, generated assets, backups. It is the default place to put them when the app is already on Neon:
 
 - **They already use Lakebase Postgres and don't want a second provider.** One backend, one bill, one CLI, one set of branches — instead of standing up and wiring a separate AWS S3 / R2 / Supabase Storage account. The same Neon credential that backs the database backs storage.
 - **Files must stay in sync with the database across environments.** Storage branches _together with_ your Postgres data. Fork a branch and the child instantly inherits the parent's buckets and objects at that point in time — copy-on-write, so no data is duplicated. This is what makes agent, dev, preview, and test environments seamless: a preview branch gets a consistent snapshot of _both_ the rows and the files they reference, and writes on the child never touch the parent.
 - **They want safe, throwaway environments.** Upload, overwrite, and delete files in a preview/CI branch without any risk to production data, then drop the branch.
 - **They want standard S3 tooling.** It's built on S3 semantics and speaks the S3 API, so the AWS SDKs, `boto3`, the AWS CLI, and presigned URLs all work — reliable and familiar, with no proprietary client.
 
-If the user has no Neon project, isn't on Postgres, and just needs a standalone CDN-backed asset store, a dedicated object store may fit better — but the moment branch-consistent files + rows matter, this is the reason to use it.
+If the files in question ship with the app itself — HTML, JS bundles, CSS, the images in `public/` — that's static web hosting and belongs on Vercel, Netlify, or Cloudflare instead. Public assets that are served from a bucket want a CDN in front of them (see [Architecture: Where Object Storage Fits](#architecture-where-object-storage-fits)).
 
 ## What It Does
 
@@ -53,7 +53,14 @@ If the user has no Neon project, isn't on Postgres, and just needs a standalone 
 
 ## Availability
 
-Check this precondition before setting anything up: Neon Object Storage is a public beta feature available only on new projects in the `us-east-2` region. Confirm the user's Neon project is a new project in `us-east-2` before proceeding; it can't be enabled on existing projects.
+Check this precondition before setting anything up: Neon Object Storage is a public beta feature available in the `us-east-2` region. Confirm the user's Neon project is in `us-east-2` before proceeding.
+
+## Architecture: Where Object Storage Fits
+
+Neon (Object Storage included) is **backend primitives, not full-stack app hosting**. Object Storage holds the files the app and its users produce — uploads, attachments, avatars, documents, generated images, backups — keyed from Postgres rows on the same branch. Two boundaries follow from that:
+
+- **Put a CDN in front of public assets.** A `public_read` object is read anonymously at `${AWS_ENDPOINT_URL_S3}/<bucket>/<object-key>` — the branch's storage endpoint, injected as an env var (see [Environment Variables](#environment-variables)). For assets a browser loads on every page view — avatars, product images, anything hot — use that as the origin for a Cloudflare or Vercel CDN, and set `Cache-Control` on `PutObject` so the edge knows how long to hold each object. A cached object is only as fresh as its key, so write each version to a new key (`avatars/<user-id>/<uuid>.jpg`) and repoint the key stored in Postgres, rather than overwriting one key and waiting out the TTL. The endpoint is branch-scoped, so a production CDN points at the production branch while preview branches read their own endpoint directly rather than sharing a cache. Private buckets stay on presigned URLs instead, which carry their signature in the query string.
+- **Host the app itself elsewhere.** Anything checked into the repo — HTML, JS bundles, CSS, and the images and fonts that ship in `public/` — belongs on Vercel, Netlify, or Cloudflare, along with the index documents, SPA fallbacks, and custom domains that go with them. Neon has no website mode to serve them through: `PutBucketWebsite` returns `501 Not Implemented`.
 
 ## Setup
 

--- a/with-files-sdk/skills-lock.json
+++ b/with-files-sdk/skills-lock.json
@@ -11,7 +11,7 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon-object-storage/SKILL.md",
-      "computedHash": "873813a63df76ff53a67679298c43701e0943f1ab14efdad8468222a363fa57d"
+      "computedHash": "8f51b1553edc959e3e0447b45c39e760a0faf2b2fec90dc8a71f0f81efb6249e"
     }
   }
 }


### PR DESCRIPTION
`with-files-sdk` and `with-ai-sdk` each vendor the `neon-object-storage` skill. [neondatabase/agent-skills#94](https://github.com/neondatabase/agent-skills/pull/94) rewrote its "When to Use" section and merged as `cdb2907`, so both copies are behind `agent-skills@main`. An agent working in either example still reads the old closer, which says a dedicated object store "may fit better" unless branch-consistent rows and files are the deciding factor, and points uploads, attachments, avatars and generated images at S3 or R2.

## What this PR is

A re-install, not an edit. Nothing here was written for this PR. Run in each example directory:

```bash
npx skills update neon-object-storage
```

Four files: each example's `.agents/skills/neon-object-storage/SKILL.md` and its `skills-lock.json` hash. `with-ai-sdk/.claude/skills/neon-object-storage` is a symlink into `.agents/`, so it follows without a separate change. Those two examples are the only places in the repo that vendor this skill.

## What the upstream change says

The old closer is replaced by two boundaries plus a new "Architecture: Where Object Storage Fits" section. Files that ship with the app (HTML, JS bundles, CSS, the images in `public/`) go to an app host. Public bucket assets want a CDN in front of the branch storage endpoint, `${AWS_ENDPOINT_URL_S3}/<bucket>/<object-key>`, with each object version written to a new key so the CDN serves the new key instead of waiting out the TTL on the old one.

## Also in here

Both vendored copies were behind by more than #94, so the refresh also brings in an earlier Availability correction. Object Storage is now described as a public beta feature available in `us-east-2`, without the "only on new projects ... it can't be enabled on existing projects" restriction the vendored text still carried. Until this merges, an agent in either example refuses to set up storage on an existing project.

## Verification

Both vendored copies are byte-identical to `agent-skills@main` (`diff` against the merged file, clean) and identical to each other. Both lock hashes moved to `8f51b1553edc959e3e0447b45c39e760a0faf2b2fec90dc8a71f0f81efb6249e`, and no other lock entry changed.

## For your attention

This repo has no CI check on vendored skill freshness, which is how the stale Availability text survived a general refresh. Thirteen other example trees carry `skills-lock.json` files for the remaining Neon skills, and each drifts on its own until someone re-runs the CLI there.
