### PR TITLE
Require with-sentry Function env at deploy

### DIFF
--- a/bots/discord-bot-http/neon.ts
+++ b/bots/discord-bot-http/neon.ts
@@ -7,9 +7,9 @@ export default defineConfig({
         name: "Discord interactions",
         source: "./functions/discord.ts",
         env: {
-          DISCORD_PUBLIC_KEY: process.env.DISCORD_PUBLIC_KEY,
-          DISCORD_APPLICATION_ID: process.env.DISCORD_APPLICATION_ID,
-          DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN,
+          DISCORD_PUBLIC_KEY: process.env.DISCORD_PUBLIC_KEY!,
+          DISCORD_APPLICATION_ID: process.env.DISCORD_APPLICATION_ID!,
+          DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN!,
           ...(process.env.DISCORD_GUILD_ID ? { DISCORD_GUILD_ID: process.env.DISCORD_GUILD_ID } : {}),
         },
         dev: {

--- a/with-sentry/.env.example
+++ b/with-sentry/.env.example
@@ -1,7 +1,9 @@
-# Sentry project DSN (sentry.io -> Settings -> Projects -> <project> -> Client Keys)
-SENTRY_DSN=
+# Required. Add this with a real DSN. A missing key throws at deploy.
+# SENTRY_DSN= with no value uploads "" and deploys with Sentry disabled.
+# SENTRY_DSN=
 
-# Optional: release identifier, e.g. the commit SHA. Blank is omitted from neon.ts.
+# Optional: release identifier, e.g. the commit SHA.
+# Leave blank; that Function env key is not uploaded.
 SENTRY_RELEASE=
 
 # Trace sample rate, 0..1 (default 1 — lower for high-volume functions)
@@ -9,5 +11,5 @@ SENTRY_TRACES_SAMPLE_RATE=1
 
 # Your project's default branch ID (br-...) — NEON_BRANCH holds the branch ID, and
 # matching it against this makes the default branch report as environment "production".
-# Blank is omitted from neon.ts.
+# Leave blank; that Function env key is not uploaded.
 PRODUCTION_BRANCH=

--- a/with-sentry/.env.example
+++ b/with-sentry/.env.example
@@ -1,12 +1,13 @@
 # Sentry project DSN (sentry.io -> Settings -> Projects -> <project> -> Client Keys)
 SENTRY_DSN=
 
-# Optional: release identifier, e.g. the commit SHA
+# Optional: release identifier, e.g. the commit SHA. Blank is omitted from neon.ts.
 SENTRY_RELEASE=
 
 # Trace sample rate, 0..1 (default 1 — lower for high-volume functions)
 SENTRY_TRACES_SAMPLE_RATE=1
 
 # Your project's default branch ID (br-...) — NEON_BRANCH holds the branch ID, and
-# matching it against this makes the default branch report as environment "production"
+# matching it against this makes the default branch report as environment "production".
+# Blank is omitted from neon.ts.
 PRODUCTION_BRANCH=

--- a/with-sentry/README.md
+++ b/with-sentry/README.md
@@ -39,7 +39,7 @@ neon login
 
 ```bash
 npm install
-cp .env.example .env   # fill SENTRY_DSN; optional keys can stay blank
+cp .env.example .env   # add SENTRY_DSN with a real value; optional keys can stay blank
 ```
 
 ## Deploy
@@ -48,6 +48,8 @@ cp .env.example .env   # fill SENTRY_DSN; optional keys can stay blank
 neon deploy --env .env
 neon functions get withsentry   # invocation_url
 ```
+
+A missing `SENTRY_DSN` makes `defineConfig` throw. `SENTRY_DSN=` with no value uploads `""` and deploys with Sentry disabled.
 
 ## Try it
 

--- a/with-sentry/README.md
+++ b/with-sentry/README.md
@@ -39,13 +39,13 @@ neon login
 
 ```bash
 npm install
-cp .env.example .env   # fill in SENTRY_DSN (and optionally the rest)
+cp .env.example .env   # fill every key declared in neon.ts Function env
 ```
 
 ## Deploy
 
 ```bash
-neon deploy
+neon deploy --env .env
 neon functions get withsentry   # invocation_url
 ```
 

--- a/with-sentry/README.md
+++ b/with-sentry/README.md
@@ -39,7 +39,7 @@ neon login
 
 ```bash
 npm install
-cp .env.example .env   # fill every key declared in neon.ts Function env
+cp .env.example .env   # fill SENTRY_DSN; optional keys can stay blank
 ```
 
 ## Deploy

--- a/with-sentry/neon.ts
+++ b/with-sentry/neon.ts
@@ -9,9 +9,13 @@ export default defineConfig({
         source: "src/index.ts",
         env: {
           SENTRY_DSN: process.env.SENTRY_DSN!,
-          SENTRY_RELEASE: process.env.SENTRY_RELEASE!,
+          ...(process.env.SENTRY_RELEASE
+            ? { SENTRY_RELEASE: process.env.SENTRY_RELEASE }
+            : {}),
           SENTRY_TRACES_SAMPLE_RATE: process.env.SENTRY_TRACES_SAMPLE_RATE ?? "1",
-          PRODUCTION_BRANCH: process.env.PRODUCTION_BRANCH!,
+          ...(process.env.PRODUCTION_BRANCH
+            ? { PRODUCTION_BRANCH: process.env.PRODUCTION_BRANCH }
+            : {}),
         },
       },
     },

--- a/with-sentry/neon.ts
+++ b/with-sentry/neon.ts
@@ -9,9 +9,9 @@ export default defineConfig({
         source: "src/index.ts",
         env: {
           SENTRY_DSN: process.env.SENTRY_DSN!,
-          SENTRY_RELEASE: process.env.SENTRY_RELEASE ?? "",
+          SENTRY_RELEASE: process.env.SENTRY_RELEASE!,
           SENTRY_TRACES_SAMPLE_RATE: process.env.SENTRY_TRACES_SAMPLE_RATE ?? "1",
-          PRODUCTION_BRANCH: process.env.PRODUCTION_BRANCH ?? "",
+          PRODUCTION_BRANCH: process.env.PRODUCTION_BRANCH!,
         },
       },
     },


### PR DESCRIPTION
## Problem

`with-sentry` tells you to copy `.env.example` and deploy. The example file shipped `SENTRY_DSN=`. A copied `.env` sets that key to `""`.

`defineConfig` accepts `""`, so the Function deploys. Sentry stays off: `instrument.ts` sets `enabled: Boolean(process.env.SENTRY_DSN)`.

`SENTRY_RELEASE` and `PRODUCTION_BRANCH` used `?? ""`. A missing key became an uploaded `""` and overwrote the live value.

The documented deploy was `neon deploy` with no `--env`, so `.env` never reached `process.env`.

## Diagnosis

`neon deploy --env FILE` loads `FILE` into `process.env`, then evaluates `neon.ts`. The object in `preview.functions.<slug>.env` is what gets written to the Function.

A declared key whose value is `undefined` is a `ConfigValidationError`.

`""` is a string, so validation passes and the empty value is written. `process.env.X!` satisfies TypeScript. Runtime throws on `undefined` and accepts `""`.

`with-sentry` used that `?? ""` fallback on optional keys. Those keys are now omitted from the env object when unset or empty.

## Interface

```ts
env: {
  SENTRY_DSN: process.env.SENTRY_DSN!,
  ...(process.env.SENTRY_RELEASE
    ? { SENTRY_RELEASE: process.env.SENTRY_RELEASE }
    : {}),
  SENTRY_TRACES_SAMPLE_RATE: process.env.SENTRY_TRACES_SAMPLE_RATE ?? "1",
  ...(process.env.PRODUCTION_BRANCH
    ? { PRODUCTION_BRANCH: process.env.PRODUCTION_BRANCH }
    : {}),
},
```

```bash
cp .env.example .env   # add SENTRY_DSN with a real value; optional keys can stay blank
neon deploy --env .env
neon functions get withsentry
```

`.env.example` comments out `SENTRY_DSN`. Copying the example and deploying throws until you add a value.

| `--env` file | Result |
| --- | --- |
| no `SENTRY_DSN` key | `defineConfig` throws |
| `SENTRY_DSN=` | uploads `""`; Sentry disabled |
| `SENTRY_DSN=<dsn>` | uploads the DSN; Sentry on |

Blank `SENTRY_RELEASE=` and `PRODUCTION_BRANCH=` are omitted. Unset `SENTRY_TRACES_SAMPLE_RATE` still uploads `"1"`.

## Also in here

Discord required keys now use `process.env.X!`, matching the WhatsApp and Telegram examples:

```ts
DISCORD_PUBLIC_KEY: process.env.DISCORD_PUBLIC_KEY!,
DISCORD_APPLICATION_ID: process.env.DISCORD_APPLICATION_ID!,
DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN!,
...(process.env.DISCORD_GUILD_ID ? { DISCORD_GUILD_ID: process.env.DISCORD_GUILD_ID } : {}),
```

`DISCORD_GUILD_ID` was already optional. `pnpm deploy` was already `neon deploy --env .env`. Missing Discord keys still throw. Empty strings still upload.

`with-sentry/README.md` documents `--env .env` and the throw vs empty-DSN cases.

## Verification

No tests in this repo evaluate `neon.ts`. None added.

`enabled: Boolean(process.env.SENTRY_DSN)` is existing code in `with-sentry/src/instrument.ts`. That file is not in the diff.

Not run: a live `neon deploy` of either example. The throw / empty-DSN / omit rows need a real `--env` file each.

## For your attention

- Discord `.env.example` still assigns empty `DISCORD_*` keys. Copying it and deploying still writes `""` for those keys.
- Omitting a key skips writing it. A live `SENTRY_RELEASE` remains until a later deploy writes a new value or `""`.
