### PR TITLE
refactor(with-realtime-chat): use @neon/functions/hono for WebSockets

### DIFF
--- a/with-realtime-chat/README.md
+++ b/with-realtime-chat/README.md
@@ -28,7 +28,7 @@ with-realtime-chat/
 ├── drizzle.config.ts       # Drizzle Kit config
 ├── .env.example            # Function environment variables
 ├── src/
-│   ├── index.ts            # Hono `fetch` + WebSocket `upgrade` (the function)
+│   ├── index.ts            # Hono app with `upgradeWebSocket` from `@neon/functions/hono`
 │   └── db/
 │       └── schema.ts       # Drizzle schema (messages)
 └── web/                    # Next.js app (Neon Auth + chat UI), deploy on Vercel
@@ -166,7 +166,7 @@ neon neon-auth domain add https://<your-app>.vercel.app
 
 ## How it works
 
-- **WebSockets on Neon Functions.** Neon Functions are long-running Node.js handlers, so the function exports `{ fetch, upgrade }`: Hono serves HTTP via `fetch`, and the `ws` library handles the WebSocket handshake in `upgrade(req, socket, head)`. See `src/index.ts`.
+- **WebSockets on Neon Functions.** The function is a Hono app exported as `export default app`. WebSockets use `upgradeWebSocket` from `@neon/functions/hono` on the `/` route — no `ws` package and no custom `upgrade` export. See `src/index.ts`.
 - **Auth over WebSockets.** Browsers can't set headers on a WebSocket, so the client passes its Neon Auth JWT as `?token=`. The function verifies it against the Neon Auth JWKS before accepting the connection.
 - **Fan-out across isolates.** Under load the runtime may run several isolates, each with its own connected clients. Every isolate polls Postgres for new messages and broadcasts them to its own sockets, so the chat stays shared across isolates without any cross-isolate messaging. See [Real-time considerations](#real-time-considerations).
 - **Reconnect.** The client reconnects with exponential backoff (re-minting a token each attempt), since serverless isolates can be evicted when idle.

--- a/with-realtime-chat/package.json
+++ b/with-realtime-chat/package.json
@@ -11,14 +11,12 @@
     "@neon/functions": "^0.8.0",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.4.2",
+    "hono": "^4.7.8",
     "jose": "^6.2.3",
-    "pg": "^8.21.0",
-    "ws": "^8.18.0"
+    "pg": "^8.21.0"
   },
   "devDependencies": {
     "@types/pg": "^8.11.10",
-    "@types/ws": "^8.5.12",
     "drizzle-kit": "^0.31.10",
     "typescript": "^5.6.3"
   }

--- a/with-realtime-chat/src/index.ts
+++ b/with-realtime-chat/src/index.ts
@@ -1,7 +1,5 @@
-import type { IncomingMessage } from 'node:http';
-import type { Duplex } from 'node:stream';
 import { Hono } from 'hono';
-import { WebSocketServer, type WebSocket } from 'ws';
+import { upgradeWebSocket } from '@neon/functions/hono';
 import { desc, gt } from 'drizzle-orm';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { parseEnv } from '@neon/env';
@@ -17,6 +15,8 @@ const jwks = createRemoteJWKSet(new URL(env.auth.jwksUrl));
 const issuer = new URL(env.auth.baseUrl).origin;
 
 type Identity = { id: string; name: string };
+
+type AppEnv = { Variables: { identity: Identity } };
 
 async function verifyToken(token: string | null): Promise<Identity | null> {
   if (!token) return null;
@@ -66,8 +66,8 @@ async function poll() {
   for (const row of rows) {
     lastId = row.id;
     const payload = JSON.stringify(row);
-    for (const ws of clients) {
-      if (ws.readyState === ws.OPEN) ws.send(payload);
+    for (const socket of clients) {
+      if (socket.readyState === socket.OPEN) socket.send(payload);
     }
   }
 }
@@ -76,35 +76,44 @@ const poller = setInterval(() => {
 }, 1000);
 poller.unref?.();
 
-const wss = new WebSocketServer({ noServer: true });
+const app = new Hono<AppEnv>();
 
-const app = new Hono();
-app.get('/', (c) => c.text('Neon realtime chat — connect over WebSocket with ?token=<jwt>'));
+app.use('/', async (c, next) => {
+  if (c.req.header('upgrade')?.toLowerCase() !== 'websocket') {
+    await next();
+    return;
+  }
+  const identity = await verifyToken(c.req.query('token') ?? null);
+  if (!identity) return c.text('Unauthorized', 401);
+  c.set('identity', identity);
+  await next();
+});
 
-export default {
-  fetch: (request: Request) => app.fetch(request),
-
-  async upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
-    const url = new URL(req.url ?? '/', 'http://localhost');
-    const identity = await verifyToken(url.searchParams.get('token'));
-    if (!identity) {
-      socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
-      socket.destroy();
-      return;
-    }
-
-    wss.handleUpgrade(req, socket, head, (ws) => {
-      clients.add(ws);
-      ws.on('close', () => clients.delete(ws));
-      ws.on('message', async (data) => {
-        const body = data.toString().slice(0, 2000).trim();
+app.get(
+  '/',
+  upgradeWebSocket((c) => {
+    const identity = c.get('identity');
+    return {
+      onOpen(_event, ws) {
+        clients.add(ws.raw);
+      },
+      onClose(_event, ws) {
+        clients.delete(ws.raw);
+      },
+      onMessage(event) {
+        const body = String(event.data).slice(0, 2000).trim();
         if (!body) return;
         // Just persist it. Every isolate's poll loop (including this one) picks
         // the new row up from Postgres and fans it out to its own clients.
-        await db
-          .insert(messages)
-          .values({ userId: identity.id, userName: identity.name, body });
-      });
-    });
-  },
-};
+        void db.insert(messages).values({
+          userId: identity.id,
+          userName: identity.name,
+          body,
+        });
+      },
+    };
+  }),
+  (c) => c.text('Neon realtime chat — connect over WebSocket with ?token=<jwt>'),
+);
+
+export default app;


### PR DESCRIPTION
## Summary
- Replace the `ws` package and custom `upgrade` export with `upgradeWebSocket` from `@neon/functions/hono`
- Auth runs in Hono middleware before the upgrade on the same URL the browser already uses (`?token=`)
- Bump `hono` to `^4.7.8` and drop `ws` / `@types/ws`

## Test plan
- [ ] `neon dev` in `with-realtime-chat`, connect from the Next.js app, send messages between two browsers
- [ ] `neon deploy` and verify `wss://` connect against the deployed function