### PR TITLE
Require bot Function env at deploy

### DIFF
--- a/bots/discord-bot-http/.env.example
+++ b/bots/discord-bot-http/.env.example
@@ -6,7 +6,7 @@
 # Optional: your test server's ID for fast guild commands; blank registers global commands.
 DISCORD_GUILD_ID=
 
-# Set automatically by Neon when running `neon deploy`.
+# Written by `neon link` or `neon env pull` (and refreshed on deploy).
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=

--- a/bots/discord-bot-http/.env.example
+++ b/bots/discord-bot-http/.env.example
@@ -1,9 +1,12 @@
-DISCORD_PUBLIC_KEY=
-DISCORD_APPLICATION_ID=
-DISCORD_BOT_TOKEN=
+# Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
+# DISCORD_PUBLIC_KEY=
+# DISCORD_APPLICATION_ID=
+# DISCORD_BOT_TOKEN=
+
+# Optional: your test server's ID for fast guild commands; blank registers global commands.
 DISCORD_GUILD_ID=
 
-# Set automatically by Neon when running `pnpm deploy`.
+# Set automatically by Neon when running `neon deploy`.
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=

--- a/bots/discord-bot-http/README.md
+++ b/bots/discord-bot-http/README.md
@@ -28,12 +28,19 @@ The Neon function slug is `discord`. The `/api/interactions` path is handled by 
 ## Requirements
 
 - Node.js 24 recommended
-- Neon CLI authenticated and linked to the target Neon project
+- Neon CLI authenticated (`neon me`)
 - A Discord application with a bot token
 
 ## Environment
 
-Copy `.env.example` to `.env.local`, then uncomment and fill in the required keys:
+Copy `.env.example` to `.env.local`, then link so Neon merges the database variables into it (linking keeps your keys):
+
+```bash
+cp .env.example .env.local
+neon link
+```
+
+Uncomment and fill in the required keys:
 
 ```env
 # Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
@@ -44,7 +51,7 @@ Copy `.env.example` to `.env.local`, then uncomment and fill in the required key
 # Optional: your test server's ID for fast guild commands; blank registers global commands.
 DISCORD_GUILD_ID=
 
-# Set automatically by Neon when running `neon deploy`.
+# Written by `neon link` or `neon env pull` (and refreshed on deploy).
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=

--- a/bots/discord-bot-http/README.md
+++ b/bots/discord-bot-http/README.md
@@ -28,21 +28,23 @@ The Neon function slug is `discord`. The `/api/interactions` path is handled by 
 ## Requirements
 
 - Node.js 24 recommended
-- pnpm 11
 - Neon CLI authenticated and linked to the target Neon project
 - A Discord application with a bot token
 
 ## Environment
 
-Fill in these keys in `.env.local`:
+Copy `.env.example` to `.env.local`, then uncomment and fill in the required keys:
 
 ```env
-DISCORD_PUBLIC_KEY=
-DISCORD_APPLICATION_ID=
-DISCORD_BOT_TOKEN=
+# Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
+# DISCORD_PUBLIC_KEY=
+# DISCORD_APPLICATION_ID=
+# DISCORD_BOT_TOKEN=
+
+# Optional: your test server's ID for fast guild commands; blank registers global commands.
 DISCORD_GUILD_ID=
 
-# Set automatically by Neon when running `pnpm deploy`.
+# Set automatically by Neon when running `neon deploy`.
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=
@@ -54,18 +56,18 @@ DATABASE_URL_UNPOOLED=
 
 `DISCORD_GUILD_ID` is optional. If set, commands are registered to one guild and update quickly. If omitted, commands are registered globally and may take longer to appear.
 
-`NEON_BRANCH`, `DATABASE_URL`, and `DATABASE_URL_UNPOOLED` are written by Neon during `pnpm deploy`. They are shown in `.env.example` for completeness; you normally do not need to fill them in by hand. The `/name` and `/profile` commands use `DATABASE_URL` to query Drizzle-managed tables.
+`NEON_BRANCH`, `DATABASE_URL`, and `DATABASE_URL_UNPOOLED` are written by Neon on your first deploy. They are shown in `.env.example` for completeness; you normally do not need to fill them in by hand. The `/name` and `/profile` commands use `DATABASE_URL` to query Drizzle-managed tables.
 
 ## Install
 
 ```bash
-pnpm install
+npm install
 ```
 
 ## Check
 
 ```bash
-pnpm check
+npm run check
 ```
 
 ## Database
@@ -73,7 +75,7 @@ pnpm check
 The `/name` command stores each Discord user's profile in Lakebase Postgres, and every slash command increments a per-user usage counter. The schema lives in `src/db/schema.ts`.
 
 ```bash
-pnpm db:push
+npm run db:push
 ```
 
 This applies the `profiles` and `command_usage` tables to the database configured by `DATABASE_URL`.
@@ -81,7 +83,7 @@ This applies the `profiles` and `command_usage` tables to the database configure
 ## Register Commands
 
 ```bash
-pnpm register:commands
+npm run register:commands
 ```
 
 This registers:
@@ -104,7 +106,7 @@ DiscordBot (https://neon.tech, Neon Functions Bot 1.0.0)
 ## Deploy
 
 ```bash
-pnpm deploy
+npm run deploy
 ```
 
 This deploys the Neon Function and writes Neon-managed env vars such as `NEON_BRANCH`, `DATABASE_URL`, and `DATABASE_URL_UNPOOLED` into `.env.local`.
@@ -112,7 +114,7 @@ This deploys the Neon Function and writes Neon-managed env vars such as `NEON_BR
 Get the current hosted function URL:
 
 ```bash
-pnpm endpoint
+npm run endpoint
 ```
 
 Append `/api/interactions` before pasting the URL into Discord.
@@ -120,7 +122,7 @@ Append `/api/interactions` before pasting the URL into Discord.
 ## Local Development
 
 ```bash
-pnpm dev
+npm run dev
 ```
 
 Neon serves the configured function from `neon.ts`.

--- a/bots/telegram-bot-http/.env.example
+++ b/bots/telegram-bot-http/.env.example
@@ -1,5 +1,8 @@
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_WEBHOOK_SECRET=
+# Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_WEBHOOK_SECRET=
+
+# Local only, used by the set:webhook script. Set after you deploy.
 TELEGRAM_WEBHOOK_URL=
 
 # Set automatically by Neon when running `neon deploy`.

--- a/bots/telegram-bot-http/.env.example
+++ b/bots/telegram-bot-http/.env.example
@@ -5,7 +5,7 @@
 # Local only, used by the set:webhook script. Set after you deploy.
 TELEGRAM_WEBHOOK_URL=
 
-# Set automatically by Neon when running `neon deploy`.
+# Written by `neon link` or `neon env pull` (and refreshed on deploy).
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=

--- a/bots/telegram-bot-http/README.md
+++ b/bots/telegram-bot-http/README.md
@@ -64,9 +64,10 @@ npm install
 
 ## Link your Neon project
 
-Link (or create) a Neon project by running the `link` command from the workspace root:
+Copy `.env.example` to `.env.local`, then link (or create) a Neon project from the workspace root. Linking merges the Neon vars into `.env.local`, keeping your keys:
 
 ```bash
+cp .env.example .env.local
 neon link
 ```
 
@@ -74,7 +75,7 @@ If you let your agent drive this, add `--agent` to skip interactive mode.
 
 ## Configure Telegram
 
-Create a bot with [BotFather](https://t.me/BotFather), then copy `.env.example` to `.env.local`, uncomment, and fill in the required keys:
+Create a bot with [BotFather](https://t.me/BotFather), then uncomment and fill in the required keys in `.env.local`:
 
 ```env
 # Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
@@ -84,7 +85,7 @@ Create a bot with [BotFather](https://t.me/BotFather), then copy `.env.example` 
 # Local only, used by the set:webhook script. Set after you deploy.
 TELEGRAM_WEBHOOK_URL=
 
-# Set automatically by Neon when running `neon deploy`.
+# Written by `neon link` or `neon env pull` (and refreshed on deploy).
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=

--- a/bots/telegram-bot-http/README.md
+++ b/bots/telegram-bot-http/README.md
@@ -74,14 +74,17 @@ If you let your agent drive this, add `--agent` to skip interactive mode.
 
 ## Configure Telegram
 
-Create a bot with [BotFather](https://t.me/BotFather), then add these keys to `.env.local` and fill in:
+Create a bot with [BotFather](https://t.me/BotFather), then copy `.env.example` to `.env.local`, uncomment, and fill in the required keys:
 
 ```env
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_WEBHOOK_SECRET=
+# Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_WEBHOOK_SECRET=
+
+# Local only, used by the set:webhook script. Set after you deploy.
 TELEGRAM_WEBHOOK_URL=
 
-# Set automatically by Neon.
+# Set automatically by Neon when running `neon deploy`.
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=

--- a/bots/whatsapp-bot-http/.env.example
+++ b/bots/whatsapp-bot-http/.env.example
@@ -4,7 +4,7 @@
 # WHATSAPP_VERIFY_TOKEN=
 # WHATSAPP_APP_SECRET=
 
-# Set automatically by Neon when running `neon deploy`.
+# Written by `neon link` or `neon env pull` (and refreshed on deploy).
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=

--- a/bots/whatsapp-bot-http/.env.example
+++ b/bots/whatsapp-bot-http/.env.example
@@ -1,7 +1,8 @@
-WHATSAPP_ACCESS_TOKEN=
-WHATSAPP_PHONE_NUMBER_ID=
-WHATSAPP_VERIFY_TOKEN=
-WHATSAPP_APP_SECRET=
+# Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
+# WHATSAPP_ACCESS_TOKEN=
+# WHATSAPP_PHONE_NUMBER_ID=
+# WHATSAPP_VERIFY_TOKEN=
+# WHATSAPP_APP_SECRET=
 
 # Set automatically by Neon when running `neon deploy`.
 NEON_BRANCH=

--- a/bots/whatsapp-bot-http/README.md
+++ b/bots/whatsapp-bot-http/README.md
@@ -73,15 +73,16 @@ If you let your agent drive this, add `--agent` to skip interactive mode.
 
 ## Configure WhatsApp
 
-Create a Meta app with WhatsApp Cloud API enabled, then add these keys to `.env.local` and fill in:
+Create a Meta app with WhatsApp Cloud API enabled, then copy `.env.example` to `.env.local`, uncomment, and fill in the required keys:
 
 ```env
-WHATSAPP_ACCESS_TOKEN=
-WHATSAPP_PHONE_NUMBER_ID=
-WHATSAPP_VERIFY_TOKEN=
-WHATSAPP_APP_SECRET=
+# Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
+# WHATSAPP_ACCESS_TOKEN=
+# WHATSAPP_PHONE_NUMBER_ID=
+# WHATSAPP_VERIFY_TOKEN=
+# WHATSAPP_APP_SECRET=
 
-# Set automatically by Neon.
+# Set automatically by Neon when running `neon deploy`.
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=

--- a/bots/whatsapp-bot-http/README.md
+++ b/bots/whatsapp-bot-http/README.md
@@ -63,9 +63,10 @@ npm install
 
 ## Link your Neon project
 
-Link (or create) a Neon project by running the `link` command from the workspace root:
+Copy `.env.example` to `.env.local`, then link (or create) a Neon project from the workspace root. Linking merges the Neon vars into `.env.local`, keeping your keys:
 
 ```bash
+cp .env.example .env.local
 neon link
 ```
 
@@ -73,7 +74,7 @@ If you let your agent drive this, add `--agent` to skip interactive mode.
 
 ## Configure WhatsApp
 
-Create a Meta app with WhatsApp Cloud API enabled, then copy `.env.example` to `.env.local`, uncomment, and fill in the required keys:
+Create a Meta app with WhatsApp Cloud API enabled, then uncomment and fill in the required keys in `.env.local`:
 
 ```env
 # Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
@@ -82,7 +83,7 @@ Create a Meta app with WhatsApp Cloud API enabled, then copy `.env.example` to `
 # WHATSAPP_VERIFY_TOKEN=
 # WHATSAPP_APP_SECRET=
 
-# Set automatically by Neon when running `neon deploy`.
+# Written by `neon link` or `neon env pull` (and refreshed on deploy).
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=


### PR DESCRIPTION
## Overview

The bot Functions require their env at deploy (`process.env.X!`), so an empty required key uploads `""` and a missing one throws. This comments the required keys out in each `.env.example` so a copied file fails loudly until you set real values, while genuinely optional keys stay uncommented.

It also corrects the `.env.local` setup order in the three bot READMEs: copy `.env.example` to `.env.local` *before* `neon link`, so the pull merges the Neon vars into the seeded file instead of the copy clobbering `DATABASE_URL`. The `.env.example` comment now credits `neon link` and `neon env pull`, not just `neon deploy`, and the Discord README moves to npm.

Follows #255, which did the require-at-deploy change for `with-sentry`.

This pull request and its description were written by Isaac.
